### PR TITLE
Bleeding pull v3 2 7

### DIFF
--- a/docs/changelog_v3.2.x.md
+++ b/docs/changelog_v3.2.x.md
@@ -3,7 +3,7 @@
 ## Prison Build Logs for v3.2.x
 
 ## Build logs
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  - [v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)&nbsp;&nbsp;
 [v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)&nbsp;&nbsp;
 [v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)&nbsp;&nbsp;

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,10 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.0 2021-04-16
 
 
+* **New feature: Add a tp warmup that is enabled within the config.yml file.**
+Able to configure the max distance the player can travel before the tp event is canceled.  Also can specify the warmup length of time, in ticks, that is used.
+
+
 * **Remove the references to mySQL and mongoDB from config.yml file since these never existed and probably won't ever exist any time soon.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,12 +20,15 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.1 2021-04-14
 
 
+* **Setup the auto feature's sellall on each block mined to suppress notifications and sounds.**
+
+
 * **Fixed a thread safety bug with the sign usage variable within the singleton.**  
 Basically it would have failed to identify a specific player as to using a sign.  If there were many players online and they all performed a sellall event, but only one using a sign, then any of the other players who were not using the sign would have a race condition and the first one to be processed would be identified as having used the sign.
 
 
-* **Also provided a way to suppress the notifications so the command can be used in slient mode, which would be beneficial for a per-block use of sellall.**
- When notifications are suppressed, it supresses the text messges and the audio.
+* **Also provided a way to suppress the notifications so the command can be used in silent mode, which would be beneficial for a per-block use of sellall.**
+ When notifications are suppressed, it suppresses the text messages and the audio.
 
 
 * **v3.3.0-alpha.1 2021-04-11**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -19,6 +19,12 @@ These represent the work that has been done on prison.
 
 # v3.3.0-alpha.1 2021-04-14
 
+* **Backpack size permission**
+Added a permission to set a _custom backpack size of a player_, it works just like permission multipliers,
+  you just need to use this permission: **prison.backpack.size.<number>** replacing <number> with
+  the custom size, **multiple of 9** that you want to use for your backpack, **example: prison.backpack.size.18** will
+  make backpacks of that player with a size of 18 slots/2 rows.
+
 
 * **Logic error on calculating the units for placeholders.**
 Was using <= instead of just < so it would produce a result of "1,000.0 K" instead of "1.0 M".

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,13 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.2 2021-04-24
 
 
+* **Backpack list add backpack button FIX**
+The backpack add button won't show if the backpacks limit for a player is set to 0.
+
+* **Backpack admin player list NPE fix**
+Fixed an NPE of the admin backpacks GUI list.
+
+
 * **Change to the maven URLs to pair them to the implementations.**
 Not sure if this will help, but it will help narrow which maven repos are related to the resources.
 There's been a problem where repos go off line and then gradle always tries and fails to locate the resources in the apache commons repo.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,9 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.2 2021-04-23
 
 
+* **Enhanced the conversion to the new block model to preserve the constraints that were added under the old block model.**
+
+
 
 * **3.3.0-alpha.2 2021-04-23**
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,10 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.2 2021-04-23
 
 
+* **Elminate all references to the config setting `use-new-prison-block-model` except for the one in the SpigotPlatform object.**
+This will allow for easier switch over to the new block model since it will be only one place that needs to be changed.  When switched over, it will support an alternative settings that will allow the forcing of the old block model.
+
+
 * **Enhanced the conversion to the new block model to preserve the constraints that were added under the old block model.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,11 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.2 2021-04-24
 
 
+* **Change to the maven URLs to pair them to the implementations.**
+Not sure if this will help, but it will help narrow which maven repos are related to the resources.
+There's been a problem where repos go off line and then gradle always tries and fails to locate the resources in the apache commons repo.
+
+
 * **Changes to the teleporting of players.**
 This fixes a potential issue with suffocation events locking a player in to an endless loop. 
 This disconnects the teleport event from the suffocation event canceling which may help address this.  The teleport event is submitted to run 3 ticks in to the future so it can also allow the suffocation event to be canceled fully.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,10 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.1 2021-04-14
 
 
+* **Logic error on calculating the units for placeholders.**
+Was using <= instead of just < so it would produce a result of "1,000.0 K" instead of "1.0 M".
+
+
 * **Setup the auto feature's sellall on each block mined to suppress notifications and sounds.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,11 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.0 2021-04-16
+# v3.3.0-alpha.1 2021-04-16
+
+
+
+* **v3.3.0-alpha.1 2021-04-16**
 
 
 * **New feature: Add a tp warmup that is enabled within the config.yml file.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,12 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.2 2021-04-26
 
 
+* **Configs support for booleans**
+Configs now support booleans values, if you delete your old ones they will work.
+  NOTE: There may still be some booleans as strings, please report them and I'll slowly try to
+  remove them.
+
+
 * **Updated a few repos:**
 XSeries, placeholderAPI, be.maximvdw.MVDWPlaceholderAPI, net.milkbowl.vault, me.lucko.luckperms.luckperms-api
 NOTE: org.bstats.bstats-bukkit v1.7 has a source code change over v1.5

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,10 +20,21 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.2 2021-04-24
 
 
-* **Backpack list add backpack button FIX**
+* **Backpack option for item on join when limit is set to 0.**
+It's now possible to give or not the backpack item to open it on join, depending on if
+  the limit is 0 or not, by default if the limit is 0 you won't have access to create a backpack and the item.
+
+
+* **Backpacks list GUI limit 0 message.**
+If a player have a limit of 0 backpacks, instead of opening an empty GUI he'll get an info
+  message telling him that he can't own backpacks.
+
+
+* **Backpack list add backpack button FIX.**
 The backpack add button won't show if the backpacks limit for a player is set to 0.
 
-* **Backpack admin player list NPE fix**
+
+* **Backpack admin player list NPE fix.**
 Fixed an NPE of the admin backpacks GUI list.
 
 
@@ -38,7 +49,7 @@ This disconnects the teleport event from the suffocation event canceling which m
 These changes also places the user one block higher above the mine so their feet are not within it.  This will help prevent the triggering of the teleport since they are no longer within the mine.  When teleporting one block higher, it will spawn a glass block under them, then that glass block will be removed in about 10 ticks.
 
 
-* **New /backpack limit decrement command**
+* **New /backpack limit decrement command.**
 This new command is just like /backpack limit add but it does the opposite, instead
   of incrementing the limit it will decrement. Format: 
   - /backpack limit decrement <Player> <DecrementNumber>, for example if you have 3 backpacks
@@ -46,7 +57,7 @@ This new command is just like /backpack limit add but it does the opposite, inst
     Multiple backpacks must be enabled to use this feature.
 
 
-* **New /backpack limit add command**
+* **New /backpack limit add command.**
 This new command is just like /backpack limit set but instead of setting a new size
   it will increment it of the number specified, format:
   - /backpack limit add <Player> <IncrementNumber>, for example if you have 2 backpacks as a limit
@@ -54,13 +65,13 @@ This new command is just like /backpack limit set but instead of setting a new s
     Multiple backpacks must be enabled to use this feature.
 
 
-* **New /backpack limit set command**
+* **New /backpack limit set command.**
 New command to set the amount of backpacks that a player can own, the format is:
   - /backpack limit set <player> <number>, for exaple /backpack limit set GABRYCA 2 will let
   me own only 2 backpacks if multiple backpacks is enabled.
 
 
-* **Backpacks DATA file structure reworked**
+* **Backpacks DATA file structure reworked.**
 Backpacks data FILE structure got edited quite a lot for some new features, more customizations
   and hopefully less bugs.
   NOTE: Upgrading from an older version may make the admin commands unusable, to fix this you need

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,10 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.2 2021-04-30
 
 
+* **v3.2.7-alpha.1 2021-04-30**
+  - Note: v3.2.7 will be released in the next few days.  This release will address a few major issues.
+  
+
 * **Bug fix: limit when the MineSweeper task will run.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,15 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.1 2021-04-22
+# v3.3.0-alpha.2 2021-04-23
+
+
+
+* **3.3.0-alpha.2 2021-04-23**
+
+
+* **added a new prison utils materialsearch that will allow the admin to search to see what materials are available.**
+Multiple search words can be used.  such as "gold axe" which will return an axe and pickaxe.
 
 
 * **More warns and less errors**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,10 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.2 2021-04-28
 
 
+* **Prevent negative values in a placeholder when the player has more money than what is needed to rankup.**  
+Since the placeholder is identifying how much is needed before ranking up, it only makes sense that once they can afford it, then they won't need more, so the value is zero.
+
+
 * **Added a new document for prison APIs.**
 It's a start, but there is a lot more that needs to be added.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,10 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.1 2021-04-16
+# v3.3.0-alpha.1 2021-04-20
+
+
+* **No need to use the singleton getInstance() since the code is already running in that very same instance: SpigotPrison.**
 
 
 * **Bug fix: The /mines blockEvent list was generating a "suggest" that was converting the & in the color codes to their raw value.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,16 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.1 2021-04-22
 
 
+* **More warns and less errors**
+GUI won't give you errors when something is wrong, but just warns, so they're
+  less allarming.
+
+
+* **Backpack won't break if size is set to 0**
+The Backpack won't break if the size is set to 0, it will open anyway with a minimum size of 9, 
+  this's because of an IllegalArgumentException error from Bukkit.
+
+
 * **Refactored the extraction of the server's version within BlueSpigetSemVerComparator so it could be included in a unit test to help ensure a specific issue with paper v1.15 was not an error within prison.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,12 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.2 2021-04-24
+# v3.3.0-alpha.2 2021-04-26
+
+
+* **Updated a few repos:**
+XSeries, placeholderAPI, be.maximvdw.MVDWPlaceholderAPI, net.milkbowl.vault, me.lucko.luckperms.luckperms-api
+NOTE: org.bstats.bstats-bukkit v1.7 has a source code change over v1.5
 
 
 * **Backpack option for item on join when limit is set to 0.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,9 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.1 2021-04-16
 
 
+* **Added a 3d distance on the Bounds to better track player movements when using tp warm ups.**
+It was using 2d distance, ignoring the y axis.
+
 
 * **v3.3.0-alpha.1 2021-04-16**
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -26,6 +26,37 @@ This disconnects the teleport event from the suffocation event canceling which m
 These changes also places the user one block higher above the mine so their feet are not within it.  This will help prevent the triggering of the teleport since they are no longer within the mine.  When teleporting one block higher, it will spawn a glass block under them, then that glass block will be removed in about 10 ticks.
 
 
+* **New /backpack limit decrement command**
+This new command is just like /backpack limit add but it does the opposite, instead
+  of incrementing the limit it will decrement. Format: 
+  - /backpack limit decrement <Player> <DecrementNumber>, for example if you have 3 backpacks
+  as a limit, /backpack limit decrement GABRYCA 2, will set my new limit to 3 - 2 = 1.
+    Multiple backpacks must be enabled to use this feature.
+
+
+* **New /backpack limit add command**
+This new command is just like /backpack limit set but instead of setting a new size
+  it will increment it of the number specified, format:
+  - /backpack limit add <Player> <IncrementNumber>, for example if you have 2 backpacks as a limit
+  then execute /backpack limit add GABRYCA 3, your new limit is 2 + 3 = 5.
+    Multiple backpacks must be enabled to use this feature.
+
+
+* **New /backpack limit set command**
+New command to set the amount of backpacks that a player can own, the format is:
+  - /backpack limit set <player> <number>, for exaple /backpack limit set GABRYCA 2 will let
+  me own only 2 backpacks if multiple backpacks is enabled.
+
+
+* **Backpacks DATA file structure reworked**
+Backpacks data FILE structure got edited quite a lot for some new features, more customizations
+  and hopefully less bugs.
+  NOTE: Upgrading from an older version may make the admin commands unusable, to fix this you need
+  to open at least one time that backpack and it will convert to the new structure, but stability or bugs
+  isn't guaranteed, the best way to avoid issues is to delete the whole backpacksdata.yml config, but
+  obviously you'd loose all the backpacks.
+
+
 * **Elminate all references to the config setting `use-new-prison-block-model` except for the one in the SpigotPlatform object.**
 This will allow for easier switch over to the new block model since it will be only one place that needs to be changed.  When switched over, it will support an alternative settings that will allow the forcing of the old block model.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,9 @@ These represent the work that has been done on prison.
 # v3.2.7-alpha.1 2021-05-01
 
 
+* **Changes to `/mines info <mineName> all` which uses the keyword all in display the full mine info, including all of the mine's reset commands and all of the mine's block events too.**
+
+
 * **Added a server run time to a few reports since it will be useful in understanding how long the server has been active.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,13 +17,16 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.2 2021-04-26
+# v3.3.0-alpha.2 2021-04-28
+
+
+* **Added a new document for prison APIs.**
+It's a start, but there is a lot more that needs to be added.
 
 
 * **Configs support for booleans**
 Configs now support booleans values, if you delete your old ones they will work.
-  NOTE: There may still be some booleans as strings, please report them and I'll slowly try to
-  remove them.
+  NOTE: There may still be some booleans as strings, please report them and I'll slowly try to remove them.
 
 
 * **Updated a few repos:**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,10 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.2 2021-04-28
+# v3.3.0-alpha.2 2021-04-30
+
+
+* **Bug fix: limit when the MineSweeper task will run.**
 
 
 * **Prevent negative values in a placeholder when the player has more money than what is needed to rankup.**  

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,10 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.0 2021-04-15
+# v3.3.0-alpha.0 2021-04-16
+
+
+* **Add a function to get a double config value from the config.yml file.**
 
 
 * **Fixes an issue if the json array for resetWarningTimes has a trailing comma, which will result in a null entry.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,13 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.2 2021-04-23
+# v3.3.0-alpha.2 2021-04-24
+
+
+* **Changes to the teleporting of players.**
+This fixes a potential issue with suffocation events locking a player in to an endless loop. 
+This disconnects the teleport event from the suffocation event canceling which may help address this.  The teleport event is submitted to run 3 ticks in to the future so it can also allow the suffocation event to be canceled fully.
+These changes also places the user one block higher above the mine so their feet are not within it.  This will help prevent the triggering of the teleport since they are no longer within the mine.  When teleporting one block higher, it will spawn a glass block under them, then that glass block will be removed in about 10 ticks.
 
 
 * **Elminate all references to the config setting `use-new-prison-block-model` except for the one in the SpigotPlatform object.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,10 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.1 2021-04-20
+# v3.3.0-alpha.1 2021-04-22
+
+
+* **Refactored the extraction of the server's version within BlueSpigetSemVerComparator so it could be included in a unit test to help ensure a specific issue with paper v1.15 was not an error within prison.**
 
 
 * **No need to use the singleton getInstance() since the code is already running in that very same instance: SpigotPrison.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,10 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.1 2021-04-16
 
 
+* **Bug fix: The /mines blockEvent list was generating a "suggest" that was converting the & in the color codes to their raw value.**
+The command `/mines blockEvent remove` now uses line number like the other commands so you no longer need to specify the whole command, just the line number.
+
+
 * **Added FastAsyncWorldEdit to Prison's soft depends.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,13 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.1 2021-04-14
+# v3.3.0-alpha.0 2021-04-15
+
+
+* **Fixes an issue if the json array for resetWarningTimes has a trailing comma, which will result in a null entry.**
+So the fix purges out any nulls, no matter where they may be.
+Also if there are no entries, it sets the reset warning times to a single entry that is one year long.  That will ensure no warnings happen, and this assumes that it was an attempt to disable the warnings.
+
 
 * **Backpack size permission**
 Added a permission to set a _custom backpack size of a player_, it works just like permission multipliers,
@@ -41,7 +47,7 @@ Basically it would have failed to identify a specific player as to using a sign.
  When notifications are suppressed, it suppresses the text messages and the audio.
 
 
-* **v3.3.0-alpha.1 2021-04-11**
+* **v3.3.0-alpha.0 2021-04-11**
 
   Start on the alpha.1 release.
   

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,9 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.1 2021-04-16
 
 
+* **Added FastAsyncWorldEdit to Prison's soft depends.**
+
+
 * **Fixed a SellAll NPE**
 If Ranks are disabled, sellall can't be used, instead of giving an error now it will
   just tell you that Ranks are disabled in a message.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,18 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.1 2021-04-16
 
 
+* **Fixed a SellAll NPE**
+If Ranks are disabled, sellall can't be used, instead of giving an error now it will
+  just tell you that Ranks are disabled in a message.
+
+
+* **Added /sellall delaysell command**
+This command's enabled by default and if triggered will work just like sellall sell but
+  it will start a countdown that won't tell you how much did you earn immediately but
+  will only at the end of it, if the same command or sellall sell is triggered during this,
+  the amount of money earned will increase and will tell you at the end the total amount.
+  
+
 * **Added a 3d distance on the Bounds to better track player movements when using tp warm ups.**
 It was using 2d distance, ignoring the y axis.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,7 +17,10 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.2 2021-04-30
+# v3.2.7-alpha.1 2021-05-01
+
+* **New feature: For all players on the server, force rank changes with one command.**
+Can use the command as `/ranks set rank *all* *same*` to reset all player's ranks to their current rank.  This will rerun the rank commands for the players so it will apply new settings.  Or you can use it like `/ranks set rank *all* A` to set all players to rank 'A', this would effectively reset the server, but also would need to use `/ranks set rank *all* -remove- prestiges` to reset the prestige ladder too.
 
 
 * **v3.2.7-alpha.1 2021-04-30**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,9 @@ These represent the work that has been done on prison.
 # v3.3.0-alpha.0 2021-04-16
 
 
+* **Remove the references to mySQL and mongoDB from config.yml file since these never existed and probably won't ever exist any time soon.**
+
+
 * **Add a function to get a double config value from the config.yml file.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,10 +17,15 @@ These represent the work that has been done on prison.
 
 
 
-# v3.3.0-alpha.1 2021-04-11
+# v3.3.0-alpha.1 2021-04-14
 
 
+* **Fixed a thread safety bug with the sign usage variable within the singleton.**  
+Basically it would have failed to identify a specific player as to using a sign.  If there were many players online and they all performed a sellall event, but only one using a sign, then any of the other players who were not using the sign would have a race condition and the first one to be processed would be identified as having used the sign.
 
+
+* **Also provided a way to suppress the notifications so the command can be used in slient mode, which would be beneficial for a per-block use of sellall.**
+ When notifications are suppressed, it supresses the text messges and the audio.
 
 
 * **v3.3.0-alpha.1 2021-04-11**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,9 @@ These represent the work that has been done on prison.
 # v3.2.7-alpha.1 2021-05-01
 
 
+* **Add a new feature to /ranks info to include rank commands when option 'all' is used.**
+
+
 * **Changes to `/mines info <mineName> all` which uses the keyword all in display the full mine info, including all of the mine's reset commands and all of the mine's block events too.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,9 @@ These represent the work that has been done on prison.
 # v3.2.7-alpha.1 2021-05-01
 
 
+* **If the mine's reset time is greater than half a second and if mine paging is turned off, a warning will be printed under /mines info that will warn the user that the reset time is high, and that they should consider turning on mine reset paging.**
+
+
 * **Add a new feature to /ranks info to include rank commands when option 'all' is used.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -19,6 +19,10 @@ These represent the work that has been done on prison.
 
 # v3.2.7-alpha.1 2021-05-01
 
+
+* **Added a server run time to a few reports since it will be useful in understanding how long the server has been active.**
+
+
 * **New feature: For all players on the server, force rank changes with one command.**
 Can use the command as `/ranks set rank *all* *same*` to reset all player's ranks to their current rank.  This will rerun the rank commands for the players so it will apply new settings.  Or you can use it like `/ranks set rank *all* A` to set all players to rank 'A', this would effectively reset the server, but also would need to use `/ranks set rank *all* -remove- prestiges` to reset the prestige ladder too.
 

--- a/docs/changelong_v3.3.x.md
+++ b/docs/changelong_v3.3.x.md
@@ -1,0 +1,29 @@
+[Prison Documents - Table of Contents](prison_docs_000_toc.md)
+
+## Prison Build Logs for v3.3.x
+
+## Build logs
+ - **[v3.3.0-alpha - Current](changelog_v3.3.x.md)**
+ - [v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)&nbsp;&nbsp;
+[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)&nbsp;&nbsp;
+[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)&nbsp;&nbsp;
+[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)&nbsp;&nbsp;
+[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)&nbsp;&nbsp;
+[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)&nbsp;&nbsp;
+[v3.2.6 - 2021-04-11](prison_changelog_v3.2.5.md)
+ 
+
+These represent the work that has been done on prison. 
+
+
+
+# v3.3.0-alpha.1 2021-04-11
+
+
+
+
+
+* **v3.3.0-alpha.1 2021-04-11**
+
+  Start on the alpha.1 release.
+  

--- a/docs/docs-commands/prison_docs_command_43_backpack.md
+++ b/docs/docs-commands/prison_docs_command_43_backpack.md
@@ -1,0 +1,40 @@
+### Prison Documentation
+[Prison Documents - Table of Contents](../prison_docs_000_toc.md)
+
+## Description:
+
+Open a list of backpacks commands.
+
+## Permission:
+
+- none
+
+## SubCommands:
+
+- `/backpack admin` `prison.admin` 
+- `/backpack delete [Backpack Owner] [id]` `prison.admin`
+- `/backpack item` 
+- `/backpack list`  
+- `/backpack set [Owner] [Size] [Optional-ID]` `prison.admin`
+
+## How to use the command
+
+Execute the command himself to use it.
+
+### Command Format
+
+`/backpack [args] [args]`
+
+## Something about backpacks.
+
+### Custom size:
+
+You can set a custom size for backpacks by commands: 
+- `/backpack set [Owner] [Size] [Optional-ID]` 
+  
+or with a size permission:
+- `prison.backpack.size.<size>` replace `<size>` with the size that you want.
+
+Always use as the size a **multiple of 9**, the size can't exceed 54.
+
+**END of the command INFO**

--- a/docs/docs-commands/prison_docs_command_43_backpack.md
+++ b/docs/docs-commands/prison_docs_command_43_backpack.md
@@ -16,6 +16,9 @@ Open a list of backpacks commands.
 - `/backpack item` 
 - `/backpack list`  
 - `/backpack set [Owner] [Size] [Optional-ID]` `prison.admin`
+- `/backpack limit set [Owner] [Limit-Value]` `prison.admin`
+- `/backpack limit add [Owner] [Limit-Increment]` `prison.admin`
+- `/backpack limit decrement [Owner] [Limit-Decrement]` `prison.admin`
 
 ## How to use the command
 
@@ -36,5 +39,10 @@ or with a size permission:
 - `prison.backpack.size.<size>` replace `<size>` with the size that you want.
 
 Always use as the size a **multiple of 9**, the size can't exceed 54.
+
+### Multiple backpacks Limit
+
+You can use `/backpack limit set/add/decrement [Owner] [Number]` to set a number of backpacks that a player can
+own, this works only if multiple backpacks's enabled. 
 
 **END of the command INFO**

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Prison's table of contents of all documents.
 
 ### Prison Build Logs for v3.2.0 (2019-12-03) through v3.2.6-alpha (current)
 
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  
  
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**
@@ -23,6 +23,11 @@ Prison's table of contents of all documents.
  - **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**
  - **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**
  - **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**
+ - **[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+
+
+ - **[v3.3.0 - 2021-??-??](prison_changelog_v3.3.x.md)**
+
 
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">
 

--- a/docs/knownissues_v3.2.x.md
+++ b/docs/knownissues_v3.2.x.md
@@ -7,14 +7,10 @@ a short list of To Do's. This list is intended to help work through known
 issues, and/or to serve as items that should be added, or fixed.
 
 
-# Random Issues - Alpha v3.2.6
-
-
-* Sometimes Player Ranks lores placeholders from placeholderAPI aren't working, 
-it's unknown why it's happening.
 
 
 # To Do Items - During Alpha v3.2.5
+
 
 
 
@@ -27,7 +23,7 @@ Should I worry about this? Prison Version: 3.2.5.  Even tho I get this message, 
 NOTE: This is not an issue.  OfficiallyGuo is running spigot 1.12.2 and trying to use concrete. More of a reason to use the new block model.
 
 
-* Warning if using `/mines set area` and volume is over 20k in size.  Could possibly be an error.
+DONE: * Warning if using `/mines set area` and volume is over 20k in size.  Could possibly be an error.
 
 
 * ladder commands
@@ -37,7 +33,7 @@ NOTE: This is not an issue.  OfficiallyGuo is running spigot 1.12.2 and trying t
 
  
 
-* TP cooldowns - for /mines tp
+DONE * TP warm ups - for /mines tp
   - Take a look at how essentialsX deals with it
 
 
@@ -58,7 +54,7 @@ DONE * Issue with `/ranks autoConfigure` if Mines module is disabled.  Gets a NP
 
 
 
-Look at sellall and XMAteral's use of parse.  Needs to handle it with an item stack.
+DONE: Look at sellall and XMAteral's use of parse.  Needs to handle it with an item stack.
 
 
 Personal mines.  Work in conjunction with a plot world?

--- a/docs/knownissues_v3.3.x.md
+++ b/docs/knownissues_v3.3.x.md
@@ -3,6 +3,9 @@
 # Prison Known Issues and To Do's for v3.3.x
 
 
+DONE: * Issue with removing a BlockEvent by clicking on the remove link.  It converts all of the & to the raw code.
+ - `/mines blockEvent remove` now uses line numbers so this is no longer an issue.
+ 
 
 * Rare condition caused by FAWEs where prison loads before CMI even though it all configured to do so otherwise.
   May be able to provide a way to force the ranks module loading so that way it can just "assume" everything is working.

--- a/docs/knownissues_v3.3.x.md
+++ b/docs/knownissues_v3.3.x.md
@@ -1,0 +1,283 @@
+[Prison Documents - Table of Contents](prison_docs_000_toc.md)
+
+# Prison Known Issues and To Do's for v3.3.x
+
+
+
+* Rare condition caused by FAWEs where prison loads before CMI even though it all configured to do so otherwise.
+  May be able to provide a way to force the ranks module loading so that way it can just "assume" everything is working.
+  
+  
+* UTF-8 support.
+
+
+* Force the loading of Ranks module if there is a failure.  Found that FAWEs is screwing up the loading sequence of prison when dealing with CMI, and as such, ranks are failing to load since CMI loads after prison.  Setting softdepend for all of these do not help.
+
+
+* Sometimes Player Ranks lores placeholders from placeholderAPI aren't working, 
+it's unknown why it's happening.
+
+
+* Fix per rank progress bars.  This includes adding a new placeholder series since you will have to include the rank name in the placeholder.  Current ladder placeholders are based upon the player's current rank only.  
+
+
+DONE * Mines TP warmup
+
+
+* BlockEvents - Action based upon blocks broken, not a percent chance.
+ - Based upon total count of blocks broken.  Example, after a player breaks 1,000 blocks, then fire a BlockEvent.
+ 
+
+ 
+* ladder commands
+
+
+* global virtual mine:  To apply mine commands & blockEvents to all other mines.
+
+
+
+* possible change to /prison version all to include errors during startup.  Errors would need to be captchured.
+
+
+
+* To `/ranks autoFeatures` add warnings at the completion identifying that the user must create any needed groups.
+ - Note that WG global region needs to have the flag `passthrough deny` set.
+
+
+
+
+Personal mines.  Work in conjunction with a plot world?
+- sellable and so would be the features with various upgrades
+- Create a new module based upon Mines with new features to support player interactions and upgrades.
+
+
+- Hook up block filters on the block events.
+
+  
+- /prison utils mining
+  - Add XP direct and ORBs
+
+
+
+
+Auto features not working outside of the mines.
+- Maybe be enabled and working now?
+- This caused issues and may have been disabled.
+
+
+
+- Add new placeholders:
+  - Top-n - Blocks mined for mines
+  - Top-n - Most active mines (based upon blocks mined)
+  - Update papi's wiki
+  - Track stats on placeholders?  Could be useful in tracking down expensive stats.
+
+
+- Top Listings
+	- Ranks & Prestiges
+	- Individual Ranks
+	- Mine base
+	- placeholders - dynamic - position in list
+	- How to dynamically keep this in memory, without lag or delays? 
+	  - Timer to track updates to player's balance so it's not always performing updates
+	- Sort order:
+	  - Ladder, Rank, percent, name
+	  - Penalty for going over 100%?
+	    - Encourage ranking up instead of sitting at one rank to dominate.
+	    - if > 100% - Take excess and get % of rankup cost and divide by 10, then subtract.
+	    - if rankup cost is 1 million and player has 2 M, then they will have a calculated rank score of 90.00.
+	      - if cost is 1 M and they have 3 M then it will score them at 80.00
+	      
+	      
+- Provide a generic placeholder that can have the value supplied through the placeholder.
+
+
+
+- Add blocks mined for players
+
+
+
+  
+- Review the chat hander in the spigot module. It was rewritten a few weeks ago to fix some issues and to optimize how things are handled.  The issue is that the new code (way of handling things) needs to be extended to other areas.  So review the SpigotPlaceholders class and see how it can be updated.  Then end result will be less code and less potential issues.
+
+- Optimize the handling of chat placeholder.  They will always be the same for the whole server, so cache the PlaceholderKeys that are used.
+  - Partially done.  The chat handler was updated, but the change could be pushed in to other existing code to improve the flexibility and resolve some of the weaknesses that may exist.
+
+
+
+  
+- Update /prison autofeatures to include new settings.
+
+
+
+- Could make /prison autofeatures reload happen. Alias: /prison reload autofeatures
+
+
+
+   
+Future Block Constraints:
+ - GradientBottom - The block has a greater chance to spawn near the bottom of the mine. 
+ - GradientTop - The block has a greater chance to spawn near the top of the mine.
+
+
+   
+   
+Maybe: Have an alt block list for mines were blocks that are not actually 
+     defined in that mine included there.  This is so air and other blocks that don't find hits can be included with the counts.  Needed for when blocks are changed so it does not lose change status?
+     
+
+
+
+
+- blockEvent
+  - simplify add - use common defaults - can change features with the other commands
+  - Add a target block name
+  - Not an issue: "Use of placeholders is failing %prison_ is failing on %p"  Turned out they were trying to use %player% instead of {player}.
+  
+  
+- auto features
+  - custom list of blocks for fortune
+
+
+
+- Issue with /ranks demote and refunding player.
+  If the current rank has a custom currency and the player is demoted with a refund,
+  the refund is credited to the wrong currency
+  - This will be easier to fix once currencies are fixed
+ 
+ 
+ 
+
+* **Custom block issues**
+- If CustomItems is loaded successfully but yet not using new block model, show error message
+- Show a message at startup indicating that the new block model is enabled or not enabled
+
+
+* **Rework rank permissions to eliminate need to put perms in rank commands**
+- Enhance the PermissionIntegration abstract class to also work with group perms.
+- Add to ranks two new fields: permissions and permissionGroups.  Save and load.
+- Add a new boolean field to ranks: usePermissions. Save and load.
+- Add support for these perms within rank commands
+- Rewrite rankups to use these perms when ranking up, promote, demote, and also for prestiges
+
+
+
+* **Prestige Options**
+ - DONE: Reset money on prestige - boolean option
+ - DONE: Prevent reset of default ladder on prestiging.
+ - Auto Prestige - server setting or player setting?
+ - prestigemax - keep applying prestiges until run out of funds
+ - DONE: rankmax - keep applying rankups until run out of funds
+ - Eliminate prestige ranks - (optional)
+   * Would need ladder commands
+   * Need to define an upper limit of how many
+   * tags may have a placeholder: `&7[&3P&a{p_level}&7]`
+   * Have a base cost of prestige: example 100,000,000
+   * Have a cost multiplier for ranks: example: 10% more expensive each rank with each prestige
+   * Have a cost multiplier for prestiging: example: 20% more expensive each prestige
+   * Have a cost multiplier for /sellall: Example: 0.005% (1/2 increase in sale price) or -0.015% (1.5% decrease in sale price to make it even more difficult per prestige)
+   * Have a list of permissions and permission groups
+   * The above settings are pretty general and would apply to all generated prestige levels, but to allow for customizations, then ladder ranks, perms and perm groups could be setup to accept a level parameter to be applied at a specific level.  Tags set at a given level could also be applied to higher levels until another tag takes it place.
+   
+
+
+- Prestiges max - if at max show 100% or Max, etc... Maybe set "max" on a placeholder attribute?
+
+- Add a prestiges config option to auto add a zero rank entry for prestige ranks.
+
+ 
+
+
+* **Get new block model working**
+  *  Start to enable and test various functions
+  *  Add in Custom Items Integration
+     *  Code Integration for CI - Key to specific version due to api changes
+     *  Pull in custom blocks from CI API
+     *  Place blocks with CI api
+     *  Not sure how block break would work with CI api?
+     *  Setup sellall to work with CI api
+     
+
+
+* **Combine a few commands & Other short Notes:**
+ - Combine `/mines set rank` and `/mines set norank`
+ - Combine `/mines set notificationPerm` with `/mines set notification`.  Add an option to enable perms.  Allow the perm to be changed? Maybe even use as a default the same permission that is used in `/ranks autoConfigure`.
+ - Combine `/mines set zeroBlockResetDelay` with `/mines set resetThreshold`
+ 
+ - Store the permission a mine uses so it can reused elsewhere (know what it is so it can be used). 
+ - move `/mines playerinventory` to `/prison player showInventory` 
+ - Add alias `/prison player info` on `/ranks player`
+ - Add alias `/prison player list` on `/ranks players`
+
+
+
+* **Value estimates for a mine**
+We know what blocks are in the mine and the percentages.  If people equally mine all blocks (some only go for the more valuable ones if they can) then we can produce a formula that can tell you how many estimated inventory fulls it would take to reach the rankup cost.  That could be a really awesome "validation" tool to make sure one or two ranks are not messed up with either being too easy or too difficult. Will need hooks in to auto manager tools to calculate fortune and what results from block breaks. Could be complex.
+`/mines value info` show breakdown of a mine's defined ores and what it would take to reach /rankup
+`/mines value list` show a listing of all mines with the key details: value per inventory full, how many inventory fulls to rankup.
+
+
+
+
+
+* **Commands - Enhancement**
+Be able to select rank and mine commands for edit and deletion, or even moving, with line numbers.
+
+* **Rank Commands - Edit and delete**
+Add line numbers and enable the ability to edit and delete by line number.
+
+
+
+
+
+* **Update config.yml when changes are detected**
+Preserving the current settings, replace the out of date config.yml file with the latest that is stored within the jar.  Updating the settings as it goes.
+
+
+* **Ladder commands - global for all ranks in that ladder**
+Add new placeholders for ladder commands to be able to have generic ladder commands that will apply and be ran for all ranks. May be able to eliminate the need for most rank commands.
+
+
+
+
+
+Enable zero block counts for parent mines.
+if 100% block type of IGNORE, then after reset do an full mine air count so zero block reset works. :)
+
+
+
+
+* **When creating a new mine, register that mine with the placeholders**
+Might be easier to just reregister all mines?  Not sure if that will work?
+Right now, if a mine is added, in order for it to show up in the placeholders, you would have to restart the server so all the placeholders are reregistered.
+ * * maybe just automatically run reset when vital elements change? * *
+
+
+
+* **Redesign the save files to eliminate the magic numbers***
+Most of the save files within prison, for players, ranks, and ladders, are
+using magic numbers which is highly prone to errors and is considered 
+very dangerous.  Also prison would benefit from a redesign in file layout
+to improve efficiencies in loading and saving, not to mention greatly reduce
+the complexities within the actual prison code, which in turn will help 
+eliminate possible bugs too and give tighter code.
+
+
+
+Offers for translation:
+  Italian : Gabryca
+  Greek : NerdTastic
+  German: DeadlyKill ?? Did not ask, but a possibility?
+  French: LeBonnetRouge
+  Portuguese: 1Pedro ? 
+  
+
+
+
+
+# Features recently added:
+
+
+
+
+

--- a/docs/prison_changelog_v3.2.0.md
+++ b/docs/prison_changelog_v3.2.0.md
@@ -3,7 +3,7 @@
 # Prison Build Logs for v3.2.0 - 2019-12-03 +
 
 ## Build logs
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
 **[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
 **[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;

--- a/docs/prison_changelog_v3.2.0.md
+++ b/docs/prison_changelog_v3.2.0.md
@@ -10,7 +10,8 @@
 **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
 **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
 **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
-**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
  
 
 Greetings!  I'm delighted that you are interested in the build logs for the

--- a/docs/prison_changelog_v3.2.1.md
+++ b/docs/prison_changelog_v3.2.1.md
@@ -3,7 +3,7 @@
 # Prison Build Logs for v3.2.1 - 2020-09-27
 
 ## Build logs
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
 **[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
 **[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;

--- a/docs/prison_changelog_v3.2.1.md
+++ b/docs/prison_changelog_v3.2.1.md
@@ -10,7 +10,8 @@
 **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
 **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
 **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
-**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
  
 
 Greetings!  I'm delighted that you are interested in the build logs for the

--- a/docs/prison_changelog_v3.2.2.md
+++ b/docs/prison_changelog_v3.2.2.md
@@ -3,7 +3,7 @@
 # Prison Build Logs for v3.2.2 - 2020-11-21
 
 ## Build logs
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
 **[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
 **[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;

--- a/docs/prison_changelog_v3.2.2.md
+++ b/docs/prison_changelog_v3.2.2.md
@@ -10,7 +10,8 @@
 **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
 **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
 **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
-**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
  
 
 Greetings!  I'm delighted that you are interested in the build logs for the

--- a/docs/prison_changelog_v3.2.3.md
+++ b/docs/prison_changelog_v3.2.3.md
@@ -3,7 +3,7 @@
 ## Prison Build Logs for v3.2.3 - 2020-12-25
 
 ## Build logs
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
 **[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
 **[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;

--- a/docs/prison_changelog_v3.2.3.md
+++ b/docs/prison_changelog_v3.2.3.md
@@ -10,7 +10,8 @@
 **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
 **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
 **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
-**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
  
 
 Greetings!  I'm delighted that you are interested in the build logs for the

--- a/docs/prison_changelog_v3.2.4.md
+++ b/docs/prison_changelog_v3.2.4.md
@@ -3,7 +3,7 @@
 ## Prison Build Logs for v3.2.4 - 2021-03-01
 
 ## Build logs
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
 **[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
 **[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;

--- a/docs/prison_changelog_v3.2.4.md
+++ b/docs/prison_changelog_v3.2.4.md
@@ -10,7 +10,8 @@
 **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
 **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
 **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
-**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
  
 
 Greetings!  I'm delighted that you are interested in the build logs for the

--- a/docs/prison_changelog_v3.2.5.md
+++ b/docs/prison_changelog_v3.2.5.md
@@ -3,7 +3,7 @@
 ## Prison Build Logs for v3.2.5 - 2021-04-01
 
 ## Build logs
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
 **[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
 **[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;

--- a/docs/prison_changelog_v3.2.5.md
+++ b/docs/prison_changelog_v3.2.5.md
@@ -10,7 +10,8 @@
 **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
 **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
 **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
-**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
  
 
 Greetings!  I'm delighted that you are interested in the build logs for the

--- a/docs/prison_changelog_v3.2.6.md
+++ b/docs/prison_changelog_v3.2.6.md
@@ -3,7 +3,7 @@
 ## Prison Build Logs for v3.2.5 - 2021-04-01
 
 ## Build logs
- - **[v3.2.6-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
 **[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
 **[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;

--- a/docs/prison_changelog_v3.2.6.md
+++ b/docs/prison_changelog_v3.2.6.md
@@ -10,7 +10,8 @@
 **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
 **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
 **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
-**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
  
 
 Greetings!  I'm delighted that you are interested in the build logs for the

--- a/docs/prison_changelog_v3.2.7.md
+++ b/docs/prison_changelog_v3.2.7.md
@@ -1,28 +1,66 @@
 [Prison Documents - Table of Contents](prison_docs_000_toc.md)
 
-## Prison Build Logs for v3.3.x
+## Prison Build Logs for v3.2.7 - 2021-05-02
 
 ## Build logs
- - **[v3.3.0-alpha - Current](changelog_v3.3.x.md)**
- - [v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)&nbsp;&nbsp;
-[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)&nbsp;&nbsp;
-[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)&nbsp;&nbsp;
-[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)&nbsp;&nbsp;
-[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)&nbsp;&nbsp;
-[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)&nbsp;&nbsp;
-[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)&nbsp;&nbsp;
-[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)
+ - **[v3.3.x - Current](changelog_v3.3.x.md)**
+ - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
+**[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
+**[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;
+**[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
+**[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
+**[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
  
 
-These represent the work that has been done on prison. 
+Greetings!  I'm delighted that you are interested in the build logs for the
+Prison plugin.  I'm wanting to provide a more formal documentation as to what 
+is going on in each build so you have a better idea if it may be something 
+that you need.
 
 
 
-# v3.3.0-alpha.1 2021-05-02
+# NOTICE : v3.2.6 had a issue with performance and release v3.2.7 fixes it
+
+
+* Significant changes to prison for improving support related commands.  The following commands are now recommended to be used to help provide details for troubleshooting.
+
+ *  /prison version all
+ *  /mines stats
+ *  /mines reset *all*
+ *  /mines list
+ *  /mines info <mineName> all
+ *  /mines stats
+ *  
+ *  /ranks ladder list
+ *  /ranks players all all
+ *  /ranks list <ladderName>
+ *  /ranks info <rankName> 
+ *  /ranks command <rankName>
+
+* If a mine is taking too long to reset, `/mines info` now includes a warning and recommends enabling Mine Reset Paging.
+
+* For all players on the server, force rank changes with one command.
+Can use the command as `/ranks set rank *all* *same*` to reset all player's ranks to their current rank.
+
+* Bug Fix: The new Mine Sweeper was added in the last release, but was accidentally always enabled.  This was fixed.
+
+
+* Significant changes and fixes for backpacks
+
+* Updated a few repos to their more recent releases
+
+* Changes to player teleport to prevent looping and locking a player in place.
+
+* Enhance how the new block model is setup to make for an easier transition to using it.
+
+
 
 
 
 # v3.2.7 2021-05-02
+
 
 
 * **Set version to v3.2.7**
@@ -222,8 +260,10 @@ Basically it would have failed to identify a specific player as to using a sign.
 * **Also provided a way to suppress the notifications so the command can be used in silent mode, which would be beneficial for a per-block use of sellall.**
  When notifications are suppressed, it suppresses the text messages and the audio.
 
-
+ 
+ 
 * **v3.3.0-alpha.0 2021-04-11**
 
   Start on the alpha.1 release.
   
+ 

--- a/docs/prison_docs_000_toc.md
+++ b/docs/prison_docs_000_toc.md
@@ -122,6 +122,7 @@ Prison now has a new set of features that can help you get up and running faster
 - [/rankupMax \[ladder\]](docs-commands/prison_docs_command_39_rankupmax.md) `ranks.user` `ranks.rankupmax` `ranks.rankupmax.[ladderName]`
 - [/rankup \[ladder\]](docs-commands/prison_docs_command_40_rankup.md) `ranks.user` `ranks.rankup.[ladderName]`
 - /gui \[gui\]
+- [/backpack](docs-commands/prison_docs_command_43_backpack.md)
 
 
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">

--- a/docs/prison_docs_000_toc.md
+++ b/docs/prison_docs_000_toc.md
@@ -16,7 +16,7 @@
 
 
 ## Build logs
- - **[v3.2.5-alpha - Current](changelog_v3.2.x.md)**
+ - **[v3.3.0.alpha.1 - Current](changelog_v3.3.x.md)**
  - **[v3.2.0 - 2019-12-03](prison_changelog_v3.2.0.md)**&nbsp;&nbsp;
 **[v3.2.1 - 2020-09-27](prison_changelog_v3.2.1.md)**&nbsp;&nbsp;
 **[v3.2.2 - 2020-11-21](prison_changelog_v3.2.2.md)**&nbsp;&nbsp;

--- a/docs/prison_docs_000_toc.md
+++ b/docs/prison_docs_000_toc.md
@@ -247,7 +247,8 @@ Get your prison setup quickly by running the command `/ranks autoCommand` which 
 * [Guide: Auto Manager - Setting Up and Enabling Other Plugins](prison_docs_311_guide_automanager.md) Enabling TokenEnchant and CrazyEnchant.
 
 
-**Work In Progress**
+* [Guide: Prison APIs](prison_docs_318_prison_APIs.md) 
+
 
 
 
@@ -271,8 +272,6 @@ This section of guides will focus more on other plugins and how they can integra
 * [Ideas on Setting up Donor Mines and Private Mines](prison_docs_628_configuring_private_mines.md)
 
 
-
-* **Work In Progress**
 
 
 

--- a/docs/prison_docs_000_toc.md
+++ b/docs/prison_docs_000_toc.md
@@ -23,7 +23,8 @@
 **[v3.2.3 - 2020-12-25](prison_changelog_v3.2.3.md)**&nbsp;&nbsp;
 **[v3.2.4 - 2021-03-01](prison_changelog_v3.2.4.md)**&nbsp;&nbsp;
 **[v3.2.5 - 2021-04-01](prison_changelog_v3.2.5.md)**&nbsp;&nbsp;
-**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**
+**[v3.2.6 - 2021-04-11](prison_changelog_v3.2.6.md)**&nbsp;&nbsp;
+**[v3.2.7 - 2021-05-02](prison_changelog_v3.2.7.md)**
 
  
  

--- a/docs/prison_docs_000_toc.md
+++ b/docs/prison_docs_000_toc.md
@@ -225,6 +225,11 @@ Get your prison setup quickly by running the command `/ranks autoCommand` which 
 
 
 
+* [Setting up Backpacks](prison_docs_117_setting_up_backpacks.md)	
+    How to enable backpacks.
+
+
+
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">
 
 

--- a/docs/prison_docs_0xx_setting_up_EssentialsX.md
+++ b/docs/prison_docs_0xx_setting_up_EssentialsX.md
@@ -64,7 +64,9 @@ Setting up Essentials is easy, but you've to choose which plugins to add.
 
 
 * Edit the `config.yml` file: 
-    - Search for the section pertaining to chat by using the keyword: **EssentialsChat**
+    - Search for the section pertaining to chat by using one of the following keywords: 
+      - **EssentialsChat** for older versions of EssentialsX for spigot v1.8 through v1.15
+      - **EssentialsX Chat** for newer versions of EssentialsX.
     - Add the placeholders {prison_rank_tag} or {prison_rank} to the "format:" line.
         * The placeholders should be **all lower case**
         * The curly braces is used by EssentialsX chat engine, not Prison. Other chat plugins may use percent symbols instead.

--- a/docs/prison_docs_107_setting_up_prestiges.md
+++ b/docs/prison_docs_107_setting_up_prestiges.md
@@ -14,12 +14,19 @@ This document provides information how to setup and use prestiges.
 This document should be able to provide the basic information to get the built in prestiges configured and working.
 
 
+Prestiges are generally used to track how many times a player has gone through all of the default ranks.  There are many variations on how prestiges are implemented, but they area always a status symbol that sets the top players from the rest.  Some features may include resetting a player's monetary balance to zero, setting their rank back to the beginning, or some other change to make the next pass through the ranks slightly different, but usually more difficult.
+  
+
+
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">
 
 
 # Enabling Prestiges
 
-By default, prestiges are disabled and must be enabled before you can use them.  Edit the following file:
+By default, prestiges are disabled and must be enabled before you can use them.  Even though the prestiges feature is disabled, prison still auto generates a prestige ladder.  
+
+
+Edit the following file:
 
 ```
 plugins/Prison/config.yml

--- a/docs/prison_docs_113_setting_up_sellall.md
+++ b/docs/prison_docs_113_setting_up_sellall.md
@@ -119,7 +119,7 @@ If everything's right, the sign will look like the sellall-sign-visible-tag from
 
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">
 
-# SellAll Auto
+# SellAll Auto:
 
 You can turn on or off from the SellAllConfig.yml file the SellAll Auto feature, which will sell everything sellable from the player inventory when it's full.
 Just edit these config lines like this:
@@ -128,6 +128,8 @@ Just edit these config lines like this:
   Full_Inv_AutoSell_Notification: 'false'
 ```
 You can edit the autoSell notification as you want.
+
+## SellAll Auto Per-User-Toggleable
 
 It's also possible to enable or disable sellAll per-User, it'll be them to choose if enable it or not.
 They'll need to use the command: `/sellall auto toggle`, it'll let them enable or disable it, when used
@@ -139,6 +141,38 @@ The admin can enable this feature from the `sellAllConfig.yml`, by changing this
 ```
 
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">
+
+# SellAll Earnings After Delay (custom /sellall sell command):
+
+## What's the command:
+
+The command is: `/sellall delaysell`.
+
+## What is it:
+It's a command enabled by default that can let you show, only after a delay, how much money
+did the player earn during that delay.
+You can disable it from the sellallconfig.yml:
+`Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Enabled: true`
+
+For example, you can add it as a blockbreakevent command in a Mine, and the first time the player
+breaks a block, a cooldown will start of the number of seconds (by default 10 but it's editable from the sellallconfig.yml, the options's: 
+`Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Delay_Seconds: 10`) that you set in the sellallconfig.yml, if you run this
+command or /sellall sell while the delay isn't over, it won't tell you how much money did you earn with that /sellall sell,
+but at the end of the delay it will tell you the total amount earned during this time.
+
+So, a pratical example:
+
+- A player breaks a block in a mine with a blockbreakevent command: /sellall delaysell.
+- The cooldown automatically starts of 10 seconds and the player sellable items get sold, he earned now 100$.
+- At 5 seconds, the player breaks another block and another /sellall delaysell command get triggered, the delay isn't over
+so there're 5 more seconds to go, he earns 10$.
+- At 7 seconds, the player uses /sellall sell because (for example) he dropped a bomb and got instantly full his inventory
+so had to clean/sell it and earns 1000$.
+- At 10 seconds, a message will show telling "You earned with AutoSell: 1110$".
+- End.
+
+<hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">
+
 
 # LIST OF COMMANDS
 ```

--- a/docs/prison_docs_117_setting_up_backpacks.md
+++ b/docs/prison_docs_117_setting_up_backpacks.md
@@ -73,3 +73,8 @@ Options:
 
 ```
 
+# Commands:
+
+Give a look to this guidebook for some extra info about backpacks: 
+[Backpacks Commands](docs-commands/prison_docs_command_43_backpack.md)
+

--- a/docs/prison_docs_117_setting_up_backpacks.md
+++ b/docs/prison_docs_117_setting_up_backpacks.md
@@ -1,0 +1,75 @@
+
+### Prison Documentation 
+[Prison Documents - Table of Contents](prison_docs_000_toc.md)
+
+# Backpacks
+
+
+Prison provides backpacks.  
+
+
+
+<hr style="height:3px; border:none; color:#aaf; background-color:#aaf;">
+
+
+# Enabling Backpacks
+
+Backpacks are disabled by default.  To enable them, you must do so through Prison's config file:
+
+`plugins/Prison/config.yml`
+
+```
+# NEW: Enable backpacks integrated within prison.
+backpacks: true
+```
+
+You will have to restart the server to apply these settings. 
+
+
+
+<hr style="height:3px; border:none; color:#aaf; background-color:#aaf;">
+
+
+# The Configuration Files
+
+
+The location of the configuration files for backpacks is as follows, along with the global configuration file:
+
+`plugins/Prison/backpacks/backpacksconfig.yml`
+
+
+The file other configuration file, `backPacksData.yml` is used to store player contents of their backpacks. 
+
+
+
+
+
+<hr style="height:3px; border:none; color:#aaf; background-color:#aaf;">
+
+
+# Settings
+
+
+```
+Options:
+  BackPack_Use_Permission_Enabled: 'false'
+  BackPack_Use_Permission: prison.backpack
+  BackPack_Default_Size: '54'
+  BackPack_AutoPickup_Usable: 'true'
+  Back_Pack_GUI_Opener_Item: 'true'
+  BackPack_Item: CHEST
+  BackPack_Item_Title: '&3Backpack'
+  BackPack_Item_OnJoin: 'true'
+  BackPack_Lose_Items_On_Death: 'false'
+  BackPack_Open_Sound_Enabled: 'true'
+  BackPack_Open_Sound: BLOCK_CHEST_OPEN
+  BackPack_Close_Sound_Enabled: 'true'
+  BackPack_Close_Sound: BLOCK_CHEST_CLOSE
+  Multiple-BackPacks-For-Player-Enabled: 'true'
+  Multiple-BackPacks-For-Player: '4'
+  DisabledWorlds:
+  - exampleWorld
+  - anotherExampleWorld
+
+```
+

--- a/docs/prison_docs_311_guide_automanager.md
+++ b/docs/prison_docs_311_guide_automanager.md
@@ -51,7 +51,7 @@ This document contains information on how to configure TokenEnchant and Crazy En
 
 
 - **Player Permissions:** You may have to first create the group within your permission plugin before you can assign it to a player.  Example using LuckPerms: `lp creategroup prison.mines.a`
-- **Player Permissions:** The player must have the permission that is tied to the afore mentioned region.  For example the group perm: `prison.mines.a`  And assign it with: `/lp user RoyalBlueRanger parent set prison.mines.a true`
+- **Player Permissions:** The player must have the permission that is tied to the afore mentioned region.  For example the group perm: `prison.mines.a`  And assign it with: `/lp user RoyalBlueRanger parent set prison.mines.a`
 
 
 

--- a/docs/prison_docs_318_prison_APIs.md
+++ b/docs/prison_docs_318_prison_APIs.md
@@ -1,0 +1,115 @@
+
+### Prison Documentation 
+[Prison Documents - Table of Contents](prison_docs_000_toc.md)
+
+# Prison's APIs and Events
+
+
+The primary focus of prison is not the Prison APIs or providing Events that can hook in to the prison internals.  
+
+But APIs do exist, and so do a few Events.  More will be added in the future too, but only on a per request basis.  So if you are trying to do something with prison that takes a lot of effort, odds are that you may need to talk to us about adding a new API to make it easier, or at least perhaps we can show you an easier way to accomplish the task.  Please contact us through discord.
+
+
+Prison does not have any formal maven repository, or similar repos.  The source is only within github so your builds will have to be performed over that, or find some other services such as https://jitpack.io/.  Your choice on how to work with the project will be up to you.
+
+
+<hr style="height:3px; border:none; color:#aaf; background-color:#aaf;">
+
+
+
+# API Classes
+
+
+There are two primary packages that contains API related classes.  One at the project level, and the other strictly through the spigot plugin.
+
+
+
+**Module: prison-core**
+
+`tech.mcprison.prison.PrisonAPI`
+
+
+**Module: prison-spigot**
+
+`tech.mcprison.prison.spigot.api.PrisonSpigotAPI`
+
+
+`tech.mcprison.prison.spigot.api.PrisonMinesBlockBreakEvent`
+
+
+
+<hr style="height:3px; border:none; color:#aaf; background-color:#aaf;">
+
+
+# Using jitpack.io as a Prison repo
+
+
+Since Prison is not setup in any public repos, you can use jitpack.io for your builds.  The following instructions are based upon the details listed at the jitpack.io website.  Since Prison uses gradle, these instructions are for gradle.  Their website has information for maven and a few other repo types.
+
+
+https://jitpack.io
+
+
+**Please Note:**  I used their webpage to construct the following directions, along with the correct settings to use, but I could not get the build to work in another project using the `implementation` keyword, but it did compile with the keyword `compileOnly`.  In this test project I do not have code that is using any of Prison's classes, so that could make a difference too.  Use of this site is your choice, but we cannot provide support if the Prison project is unable to be compiled in your project.  - Blue
+
+
+
+Look up the repository.  On the main page of jitpack.io enter `com.github.PrisonTeam/Prison` in to the search field and press the button "**Look Up**".  It will return information on prison's commits to the master branch.  
+
+
+Next you will see a table of versions with tabs at the top (they don't look like tabs). Click on the tab named "Builds".  This will show a list of Versions. For example it will include "v3.2.6" and "3.2.6", but look under the Status column.  Select one that has "Get It" button to populate the examples at the bottom of the page.
+
+
+
+If you need to use the current bleeding branch use `com.github.PrisonTeam/Prison/bleeding`
+
+
+
+First, you need to add jitpack.io to the your repository listing.
+
+```
+allprojects {
+	repositories {
+		...
+		maven { url 'https://jitpack.io' }
+	}
+}
+```
+
+
+Then you need to add the jitpack.io dependency as the very last of your dependencies.
+
+
+This is the generic format:
+
+```
+dependencies {
+	implementation 'com.github.User:Repo:bleeding-SNAPSHOT'
+}
+```
+
+
+This is the formated version for Prison's master branch:
+
+```
+dependencies {
+	implementation 'com.github.PrisonTeam:Prison:3.2.6'
+}
+```
+
+
+The following is for the bleeding branch snapshot, and is using the `compileOnly` keyword instead of `implementation`.
+
+```
+dependencies {
+	compileOnly 'com.github.PrisonTeam:Prison:bleeding-SNAPSHOT'
+}
+```
+
+Then all that is left is to build the project.  
+
+
+
+<hr style="height:3px; border:none; color:#aaf; background-color:#aaf;">
+
+

--- a/docs/prison_docs_626_configuring_worldguard_regions.md
+++ b/docs/prison_docs_626_configuring_worldguard_regions.md
@@ -378,22 +378,22 @@ NOTE: With world guard we had to use the prefix of `g:` to indicate the permissi
 
 Template and examples as used in rank commands using **parent set**, you may want to actually use **parent add** instead:
 
-    /lp user <player-name> parent set <group-name> true
+    /lp user <player-name> parent set <group-name>
 
-    /lp user <player-name> parent set prison.mines.<mine-name> true
+    /lp user <player-name> parent set prison.mines.<mine-name>
 
-    /lp user {player} parent set prison.mines.a true
-    /lp user {player} parent set prison.mines.b true
+    /lp user {player} parent set prison.mines.a
+    /lp user {player} parent set prison.mines.b
 
 
 Examples using **parent add** for the groups:
 
-    /lp user <player-name> parent add <group-name> true
+    /lp user <player-name> parent add <group-name>
 
-    /lp user <player-name> parent add prison.mines.<mine-name> true
+    /lp user <player-name> parent add prison.mines.<mine-name>
 
-    /lp user {player} parent add prison.mines.a true
-    /lp user {player} parent add prison.mines.b true
+    /lp user {player} parent add prison.mines.a
+    /lp user {player} parent add prison.mines.b
 
 
 
@@ -441,17 +441,17 @@ The following is an example of adding and removing a permission to a player.  Th
 
 Based upon the above documentation, and from within game, we would use the following to *manually* give a player a permission:
 
-    /lp user <player-name> parent add prison.mines.<mine-name> true
+    /lp user <player-name> parent add prison.mines.<mine-name>
 
 
 For example, if you have a player named *AHappyPrisoner* And you have a mine named "a" you would use the following command:
 
-    /lp user AHappyPrisoner parent add prison.mines.a true
+    /lp user AHappyPrisoner parent add prison.mines.a
 
 
 To run the **a** rank commands when the player uses **/rankup**, the following is the command for **/ranks command add <rankName>**:
 
-	/ranks command add a lp user {player} parent add prison.mines.a true
+	/ranks command add a lp user {player} parent add prison.mines.a
 
 
 Notice how the manually entered command is used with the **/ranks command add <rankName>**?  Just drop the leading slash and it should be good.
@@ -675,7 +675,7 @@ So finally for our example of setting up mines a and b, we now need to add the R
 
 For rank a:
 
-    /ranks command add a lp user {player} parent add prison.mines.a true
+    /ranks command add a lp user {player} parent add prison.mines.a
     /ranks command add a lp user {player} parent remove prison.mines.b
     /ranks command add a lp user {player} permission set mines.tp.a true
     /ranks command add a lp user {player} permission unset mines.tp.b
@@ -683,7 +683,7 @@ For rank a:
 
 For rank b:
 
-    /ranks command add b lp user {player} parent add prison.mines.b true
+    /ranks command add b lp user {player} parent add prison.mines.b
     /ranks command add b lp user {player} parent remove prison.mines.c
     /ranks command add b lp user {player} permission set mines.tp.b true
     /ranks command add b lp user {player} permission unset mines.tp.c
@@ -736,8 +736,8 @@ Some LuckPerm commands that may be useful.
     /lp group prison.mines.a info
     
     
-    /lp user <user-name> parent set <group-name> true
-    /lp user <user-name> parent add <group-name> true
+    /lp user <user-name> parent set <group-name>
+    /lp user <user-name> parent add <group-name>
     /lp user <user-name> parent remove <group-name>
     
     /lp user <user-name> permission set <permission-name> true

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,8 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.3.0-alpha.2
+version=3.2.7-alpha.1
+#version=3.3.0-alpha.2
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.3.0-alpha.1
+version=3.3.0-alpha.2
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.2.7-alpha.1
+version=3.2.7
 #version=3.3.0-alpha.2
 
 ## org.gradle.warning.mode=(all,none,summary)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.3.0-alpha.0
+version=3.3.0-alpha.1
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.2.6
+version=3.3.0-alpha.0
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/prison-core/src/main/java/tech/mcprison/prison/Prison.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/Prison.java
@@ -34,6 +34,7 @@ import tech.mcprison.prison.modules.ModuleManager;
 import tech.mcprison.prison.modules.PluginEntity;
 import tech.mcprison.prison.output.Output;
 import tech.mcprison.prison.placeholders.PlaceholderManager;
+import tech.mcprison.prison.placeholders.PlaceholdersUtil;
 import tech.mcprison.prison.selection.SelectionManager;
 import tech.mcprison.prison.store.Database;
 import tech.mcprison.prison.troubleshoot.TroubleshootManager;
@@ -64,11 +65,13 @@ public class Prison
 	public static final int SPIGOTMC_ORG_PROJECT_ID = 1223; //72740;
 	
     // Singleton
+	private static Prison instance = null;
 
     public static final int API_LEVEL = 3;
-    private static Prison instance = null;
     
     private String minecraftVersion;
+    
+    private long serverStartupTime;
 
     // Fields
     private Platform platform;
@@ -89,6 +92,11 @@ public class Prison
     private Database metaDatabase;
     
     
+    private Prison() {
+    	super();
+    	
+    	this.serverStartupTime = System.currentTimeMillis();
+    }
 
     /**
      * Gets the current instance of this class. <p> An instance will always be available after
@@ -176,6 +184,7 @@ public class Prison
     	Output.get().logInfo("&7Loading Prison version: &3%s", PrisonAPI.getPluginVersion());
     	Output.get().logInfo("&7Running on platform: &3%s", platform.getClass().getSimpleName());
     	Output.get().logInfo("&7Minecraft version: &3%s", getMinecraftVersion());
+    	Output.get().logInfo("&7Server runtime: %s", getServerRuntimeFormatted() );
     	Output.get().logInfo("");
     }
 
@@ -379,5 +388,18 @@ public class Prison
     	return placeholderManager;
     }
     
+    
+    public long getServerStartupTime() {
+		return serverStartupTime;
+	}
+	public void setServerStartupTime( long serverStartupTime ) {
+		this.serverStartupTime = serverStartupTime;
+	}
+
+	public String getServerRuntimeFormatted() {
+    	long currentTime = System.currentTimeMillis();
+    	long runtimeMs = currentTime - getServerStartupTime();
+    	return PlaceholdersUtil.formattedTime( runtimeMs / 1000 );
+    }
     
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/PrisonCommand.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/PrisonCommand.java
@@ -242,6 +242,8 @@ public class PrisonCommand {
         display.addText("&7Running on Platform: %s", Prison.get().getPlatform().getClass().getName());
         display.addText("&7Minecraft Version: %s", Prison.get().getMinecraftVersion());
 
+        display.addText("&7Server runtime: %s", Prison.get().getServerRuntimeFormatted() );;
+        
         display.addText("");
         
         display.addText("&7Prison's root Command: /prison");

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlock.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlock.java
@@ -14,6 +14,7 @@ public class PrisonBlock
 			implements Comparable<PrisonBlock> {
 	
 	public static PrisonBlock AIR;
+	public static PrisonBlock GLASS;
 	public static PrisonBlock IGNORE;
 	public static PrisonBlock NULL_BLOCK;
 	
@@ -31,6 +32,7 @@ public class PrisonBlock
 	
 	static {
 		AIR = new PrisonBlock( InternalBlockTypes.AIR.name(), false );
+		GLASS = new PrisonBlock( InternalBlockTypes.GLASS.name(), true );
 		IGNORE = new PrisonBlock( InternalBlockTypes.IGNORE.name(), false );
 		NULL_BLOCK = new PrisonBlock( InternalBlockTypes.NULL_BLOCK.name(), false );
 	}

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlockStatusData.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlockStatusData.java
@@ -142,6 +142,24 @@ public abstract class PrisonBlockStatusData {
 		}
 	}
 	
+	/**
+	 * This function transfers all stats from an old block to this existing block. 
+	 * The data is replaced, not "added" so use cautiously.
+	 * 
+	 * @param oldBlock
+	 */
+	public void transferStats( PrisonBlockStatusData oldBlock ) {
+		if ( oldBlock != null ) {
+			
+			setChance( oldBlock.getChance() );
+			setBlockCountTotal( oldBlock.getBlockCountTotal() );
+			setConstraintMin( oldBlock.getConstraintMin() );
+			setConstraintMax( oldBlock.getConstraintMax() );
+			setConstraintExcludeTopLayers( oldBlock.getConstraintExcludeTopLayers() );
+			setConstraintExcludeBottomLayers( oldBlock.getConstraintExcludeBottomLayers() );
+		}
+	}
+	
 	public String toPlaceholderString() {
 		StringBuilder sb = new StringBuilder();
 		

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlockTypes.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlockTypes.java
@@ -19,6 +19,7 @@ public class PrisonBlockTypes {
 	
 	public enum InternalBlockTypes {
 		AIR,
+		GLASS,
 		IGNORE,
 		NULL_BLOCK
 	}

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/platform/Platform.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/platform/Platform.java
@@ -289,6 +289,8 @@ public interface Platform {
 	public int getConfigInt( String key, int defaultValue );
 	
 	public long getConfigLong( String key, long defaultValue );
+
+	public double getConfigDouble( String key, double defaultValue );
 	
 
     /**

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/platform/Platform.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/platform/Platform.java
@@ -275,6 +275,19 @@ public interface Platform {
 	
 
 	/**
+	 * <p>This is the only way to find out if the new block model is enabled.
+	 * </p>
+	 * 
+	 * <p>This should be the only place within prison to use the actual String value of the
+	 * permission.  This will allow for a simple change in the future.
+	 * </p>
+	 * 
+	 * @return
+	 */
+	public boolean isUseNewPrisonBlockModel();
+	
+	
+	/**
 	 * <p>This returns the boolean value that is associated with the key.
 	 * It has to match on true to return a true value, but if the key does
 	 * not exist, then it returns a value of true.  Default value is true.
@@ -333,6 +346,7 @@ public interface Platform {
 	 * @return
 	 */
 	public List<String> getActiveFeatures();
-	
+
+
 	
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/placeholders/PlaceholdersUtil.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/placeholders/PlaceholdersUtil.java
@@ -106,7 +106,7 @@ public class PlaceholdersUtil {
 	}
 	
 	private static double divBy1000( double amount, StringBuilder unit, String units ) {
-    	if ( amount <= 1000.0 || units.length() == 1 ) {
+    	if ( amount < 1000.0 || units.length() == 1 ) {
     		unit.append( units.subSequence( 0, 1 ) );
     	}
     	else {
@@ -139,7 +139,7 @@ public class PlaceholdersUtil {
     	if ( prefixesBinary.size() == 0) {
     		// no prefixesBinary units have been defined, so exit returning the original amount:
     	}
-    	else if ( amount <= 1024.0 || prefixesBinary.size() == (prefixesBinaryPos + 1)) {
+    	else if ( amount < 1024.0 || prefixesBinary.size() == (prefixesBinaryPos + 1)) {
     		unit.append( prefixesBinary.get( prefixesBinaryPos ) );
     	}
     	else {

--- a/prison-core/src/main/java/tech/mcprison/prison/util/Bounds.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/util/Bounds.java
@@ -421,6 +421,14 @@ public class Bounds {
     	double distance = Math.sqrt( (deltaX * deltaX)  + (deltaZ * deltaZ) );
     	return Math.round( distance );
     }
+    
+    public double getDistance3d() {
+    	double deltaX = getMin().getX() - getMax().getX();
+    	double deltaY = getMin().getY() - getMax().getY();
+    	double deltaZ = getMin().getZ() - getMax().getZ();
+    	double distance = Math.sqrt( (deltaX * deltaX) + (deltaY * deltaY)  + (deltaZ * deltaZ) );
+    	return Math.round( distance );
+    }
   
     public double getDistance(Location location) {
     	double deltaX = getCenter().getX() - location.getX();

--- a/prison-core/src/test/java/tech/mcprison/prison/TestPlatform.java
+++ b/prison-core/src/test/java/tech/mcprison/prison/TestPlatform.java
@@ -256,6 +256,11 @@ public class TestPlatform implements Platform {
 	}
 	
 	@Override
+	public double getConfigDouble( String key, double defaultValue ) {
+		return defaultValue;
+	}
+	
+	@Override
 	public PrisonBlockTypes getPrisonBlockTypes() {
 		return null;
 	}

--- a/prison-core/src/test/java/tech/mcprison/prison/TestPlatform.java
+++ b/prison-core/src/test/java/tech/mcprison/prison/TestPlatform.java
@@ -236,6 +236,11 @@ public class TestPlatform implements Platform {
 	}
 	
 	@Override
+	public boolean isUseNewPrisonBlockModel() {
+		return false;
+	}
+	
+	@Override
 	public boolean getConfigBooleanFalse( String key ) {
 		return false;
 	}

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/MinesListener.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/MinesListener.java
@@ -6,7 +6,9 @@ import tech.mcprison.prison.internal.Player;
 import tech.mcprison.prison.internal.events.player.PlayerSuffocationEvent;
 import tech.mcprison.prison.internal.events.world.PrisonWorldLoadEvent;
 import tech.mcprison.prison.mines.data.Mine;
+import tech.mcprison.prison.mines.tasks.MineTeleportWarmUpTask;
 import tech.mcprison.prison.selection.SelectionCompletedEvent;
+import tech.mcprison.prison.tasks.PrisonTaskSubmitter;
 import tech.mcprison.prison.util.Bounds;
 
 /**
@@ -40,9 +42,25 @@ public class MinesListener {
     	if ( mine != null ) {
     		e.setCanceled( true );
     		
-    		mine.teleportPlayerOut( player );
+    		// Submit the teleport task to run in 3 ticks.  This will allow the suffocation
+    		// event to be canceled.  If the player moves then they don't need to be teleported
+    		// so it will be canceled.
+    		MineTeleportWarmUpTask mineTeleportWarmUp = new MineTeleportWarmUpTask( 
+    							player, mine, "spawn", 0.5 );
+    		mineTeleportWarmUp.setMessageSuccess( 
+    							"&7You have been teleported out of the mine to prevent suffocating." );
+    		mineTeleportWarmUp.setMessageFailed( null );
     		
-    		player.sendMessage( "&7You have been teleported out of the mine to prevent suffocating." );
+    		PrisonTaskSubmitter.runTaskLater( mineTeleportWarmUp, 3 );
+//    		mine.teleportPlayerOut( player );
+//    		
+//    		
+//    		// To "move" the player out of the mine, they are elevated by one block above the surface
+//    		// so need to remove the glass block if one is spawned under them.  If there is no glass
+//    		// block, then it will do nothing.
+//    		mine.submitTeleportGlassBlockRemoval();
+    		
+//    		player.sendMessage( "&7You have been teleported out of the mine to prevent suffocating." );
     	}
     	else {
     		player.sendMessage( "&7You cannot be teleported to safety.  Good luck." );

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -3402,6 +3402,11 @@ public class MinesCommands
     	else {
     		
     		mine.teleportPlayerOut( player, target );
+    		
+    		// To "move" the player out of the mine, they are elevated by one block above the surface
+    		// so need to remove the glass block if one is spawned under them.  If there is no glass
+    		// block, then it will do nothing.
+    		mine.submitTeleportGlassBlockRemoval();
     	}
     	
 

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -931,7 +931,7 @@ public class MinesCommands
     	
     	ChatDisplay display = null;
     	
-        if ( Prison.get().getPlatform().getConfigBooleanFalse( "use-new-prison-block-model" ) ) {
+        if ( Prison.get().getPlatform().isUseNewPrisonBlockModel() ) {
             
         	display = prisonBlockSearchBuilder(search, page, true, "mines block search");
         }
@@ -959,7 +959,7 @@ public class MinesCommands
     	
     	ChatDisplay display = null;
     	
-    	if ( Prison.get().getPlatform().getConfigBooleanFalse( "use-new-prison-block-model" ) ) {
+    	if ( Prison.get().getPlatform().isUseNewPrisonBlockModel() ) {
     		
     		display = prisonBlockSearchBuilder(search, page, false, "mines block searchAll");
     	}

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -1586,6 +1586,14 @@ public class MinesCommands
         		}
         		
         		chatDisplay.addComponent( row );
+        		
+        		double resetTimeSeconds = m.getStatsResetTimeMS() / 1000.0;
+        		if ( !m.isUsePagingOnReset() && resetTimeSeconds > 0.5 ) {
+        			String resetTimeSec = PlaceholdersUtil.formattedTime( resetTimeSeconds );
+        			chatDisplay.addText("&5  Warning: &3Reset time is &7%s&3, which is high. " +
+        					"It is recommened that you try to enable &7/mines set resetPaging help",
+        					resetTimeSec );
+        		}
         	}
         	
         	if ( !m.isVirtual() ) {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -3652,7 +3652,7 @@ public class MinesCommands
         	
         	FancyMessage msgRemove = new FancyMessage( String.format( " &4Remove&3", 
         			blockEvent.getCommand() ) )
-        			.suggest("/mines blockEvent remove " + m.getName() + " " + blockEvent.getCommand() )
+        			.suggest("/mines blockEvent remove " + m.getName() + " " + rowNumber )
         			.tooltip("Click to Delete this BlockEvent");
         	row.addFancy( msgRemove );
         	
@@ -3686,13 +3686,16 @@ public class MinesCommands
     		onlyPlayers = false, permissions = "mines.set")
     public void blockEventRemove(CommandSender sender, 
     				@Arg(name = "mineName") String mineName,
-    				@Arg(name = "command", description = "Exact BlockEvent command to remove") 
-    						@Wildcard String command) {
+    				@Arg(name = "row") Integer row) {
     	
-        if (command.startsWith("/")) {
-            command = command.replaceFirst("/", "");
+        if ( row == null || row <= 0 ) {
+        	sender.sendMessage( 
+        			String.format("&7Please provide a valid row number greater than zero. " +
+        					"Was row=[&b%d&7]",
+        					(row == null ? "null" : row) ));
+        	return;        	
         }
-    	
+        
         if (!performCheckMineExists(sender, mineName)) {
             return;
         }
@@ -3708,12 +3711,23 @@ public class MinesCommands
             return;
         }
 
-        if ( m.getBlockEventsRemove(command) ) {
+        if ( row > m.getBlockEvents().size() ) {
+        	sender.sendMessage( 
+        			String.format("&7Please provide a valid row number no greater than &b%d&7. " +
+        					"Was row=[&b%d&7]",
+        					m.getBlockEvents().size(), (row == null ? "null" : row) ));
+        	return;        	
+        }
+        
+        MineBlockEvent blockEvent = m.getBlockEvents().get( row - 1 );
+        
+        
+        if ( blockEvent != null && m.getBlockEventsRemove( blockEvent ) ) {
         	
         	pMines.getMineManager().saveMine( m );
             	
         	Output.get().sendInfo(sender, "Removed BlockEvent command '%s' from the mine '%s'.", 
-        				command, m.getTag());
+        				blockEvent.getCommand(), m.getTag());
         } else {
         	Output.get().sendWarn(sender, 
         			String.format("The mine %s doesn't contain that BlockEvent command. Nothing was changed.", 

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -1446,6 +1446,9 @@ public class MinesCommands
         
         ChatDisplay chatDisplay = new ChatDisplay("&bMine: &3" + m.getName());
 
+        chatDisplay.addText("&7Server runtime: %s", Prison.get().getServerRuntimeFormatted() );;
+
+
         // Display Mine Info only:
         if ( cmdPageData.getCurPage() == 1 ) {
         	

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -53,6 +53,7 @@ import tech.mcprison.prison.mines.features.MineLinerBuilder;
 import tech.mcprison.prison.mines.features.MineLinerBuilder.LinerPatterns;
 import tech.mcprison.prison.mines.managers.MineManager;
 import tech.mcprison.prison.mines.managers.MineManager.MineSortOrder;
+import tech.mcprison.prison.mines.tasks.MineTeleportWarmUpTask;
 import tech.mcprison.prison.modules.ModuleElementType;
 import tech.mcprison.prison.output.BulletedListComponent;
 import tech.mcprison.prison.output.ChatDisplay;
@@ -63,6 +64,7 @@ import tech.mcprison.prison.output.RowComponent;
 import tech.mcprison.prison.placeholders.PlaceholdersUtil;
 import tech.mcprison.prison.selection.Selection;
 import tech.mcprison.prison.tasks.PrisonCommandTask.TaskMode;
+import tech.mcprison.prison.tasks.PrisonTaskSubmitter;
 import tech.mcprison.prison.util.BlockType;
 import tech.mcprison.prison.util.Bounds;
 import tech.mcprison.prison.util.Bounds.Edges;
@@ -3371,17 +3373,40 @@ public class MinesCommands
         
     	if ( isOp && playerAlt != null && playerAlt.isOnline() ) {
     		
-    		m.teleportPlayerOut( playerAlt, target );
+    		teleportPlayer( playerAlt, m, target );
+//    		m.teleportPlayerOut( playerAlt, target );
     	}
     	else if ( sender.isPlayer() ) {
-    		m.teleportPlayerOut( (Player) sender, target );
+    		teleportPlayer( (Player) sender, m, target );
+//    		m.teleportPlayerOut( (Player) sender, target );
     	} else {
     		sender.sendMessage(
     	            "&3Telport failed. Are you sure you're a Player?");
     	}
     }
 
-    
+    private void teleportPlayer( Player player, Mine mine, String target ) {
+    	
+    	if ( Prison.get().getPlatform().getConfigBooleanFalse( "prison-mines.tp-warmup.enabled" ) ) {
+    		
+    		// if warm up enabled:
+    		double maxDistance = Prison.get().getPlatform().
+    							getConfigDouble( "prison-mines.tp-warmup.movementMaxDistance", 1.0 );
+    		long delayInTicks = Prison.get().getPlatform().
+    							getConfigLong( "prison-mines.tp-warmup.delayInTicks", 20 );
+    		
+    		MineTeleportWarmUpTask mineTeleportWarmUp = new MineTeleportWarmUpTask( 
+    							player, mine, target, maxDistance );
+    		PrisonTaskSubmitter.runTaskLater( mineTeleportWarmUp, delayInTicks );
+    	}
+    	else {
+    		
+    		mine.teleportPlayerOut( player, target );
+    	}
+    	
+
+
+    }
     
     @Command(identifier = "mines stats", permissions = "mines.stats", description = "Toggle stats on all mines.")
     public void mineStats(CommandSender sender) {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/Mine.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/Mine.java
@@ -441,12 +441,12 @@ public class Mine
         		getPrisonBlocks().size() == 0 && getBlocks().size() > 0 ) {
         	// Need to perform the initial conversion: 
         	
-        	for ( BlockOld block : getBlocks() ) {
-        		PrisonBlock prisonBlock = Prison.get().getPlatform().getPrisonBlock( block.getType().name() );
+        	for ( BlockOld blockOld : getBlocks() ) {
+        		PrisonBlock prisonBlock = Prison.get().getPlatform().getPrisonBlock( blockOld.getType().name() );
             	if ( prisonBlock != null ) {
             		
-            		prisonBlock.setChance( block.getChance() );
-            		prisonBlock.setBlockCountTotal( block.getBlockCountTotal() );
+            		// This transfers all the stats over so none are lost.
+            		prisonBlock.transferStats( blockOld );
             		
             		addPrisonBlock( prisonBlock );
 

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineData.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineData.java
@@ -223,8 +223,7 @@ public abstract class MineData
 			this.useNewBlockModel = false;
 		}
 		else {
-			this.useNewBlockModel = Prison.get().getPlatform()
-								.getConfigBooleanFalse( "use-new-prison-block-model" );
+			this.useNewBlockModel = Prison.get().getPlatform().isUseNewPrisonBlockModel();
 		}
     }
 

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineData.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineData.java
@@ -1085,8 +1085,17 @@ public abstract class MineData
 		this.blockEvents = blockEvents;
 	}
 	
-	public boolean getBlockEventsRemove( String command ) {
+	public boolean getBlockEventsRemove( MineBlockEvent blockEvent ) {
 		boolean results = false;
+		
+		if ( blockEvent != null ) {
+			results = getBlockEvents().remove( blockEvent );
+		}
+		
+		return results;
+	}
+	
+	public boolean getBlockEventsRemove( String command ) {
 		MineBlockEvent blockEvent = null;
 		for ( MineBlockEvent be : getBlockEvents() ) {
 			if ( be.getCommand().equalsIgnoreCase( command ) ) {
@@ -1094,11 +1103,7 @@ public abstract class MineData
 			}
 		}
 		
-		if ( blockEvent != null ) {
-			results = getBlockEvents().remove( blockEvent );
-		}
-		
-		return results;
+		return getBlockEventsRemove( blockEvent );
 	}
 
 	public MineLinerData getLinerData() {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
@@ -218,7 +218,7 @@ public abstract class MineReset
 			}
 			
 			
-			teleportAllPlayersOut( getBounds().getyBlockMax() );
+			teleportAllPlayersOut();
 //			setStatsTeleport1TimeMS(
 //					teleportAllPlayersOut( getBounds().getyBlockMax() ) );
 			
@@ -257,7 +257,7 @@ public abstract class MineReset
 			// If a player falls back in to the mine before it is fully done being reset, 
 			// such as could happen if there is lag or a lot going on within the server, 
 			// this will TP anyone out who would otherwise suffocate.  I hope! lol
-			teleportAllPlayersOut( getBounds().getyBlockMax() );
+			teleportAllPlayersOut();
 //			setStatsTeleport2TimeMS(
 //					teleportAllPlayersOut( getBounds().getyBlockMax() ) );
 			
@@ -288,6 +288,10 @@ public abstract class MineReset
 			// Broadcast message to all players within a certain radius of this mine:
 			broadcastResetMessageToAllPlayersWithRadius();
 //			broadcastResetMessageToAllPlayersWithRadius( MINE_RESET__BROADCAST_RADIUS_BLOCKS );
+			
+			
+			submitTeleportGlassBlockRemoval();
+			
 			
 			// If part of a chained_resets, then kick off the next reset:
 			if ( getCurrentJob().getResetActions().contains( MineResetActions.CHAINED_RESETS )) {
@@ -407,17 +411,19 @@ public abstract class MineReset
     }
 	
 
-    protected abstract long teleportAllPlayersOut(int targetY);
+    protected abstract long teleportAllPlayersOut();
     
     
     public abstract void teleportPlayerOut(Player player);
     
 
-    public abstract void teleportPlayerOut(Player player, String targetLocation);
+    public abstract Location teleportPlayerOut(Player player, String targetLocation);
 
 
 	public abstract Location alternativeTpLocation();
 	
+	
+	public abstract void submitTeleportGlassBlockRemoval();
 	
 	
     /**
@@ -651,7 +657,7 @@ public abstract class MineReset
         		// If a player falls back in to the mine before it is fully done being reset, 
         		// such as could happen if there is lag or a lot going on within the server, 
         		// this will TP anyone out who would otherwise suffocate.  I hope! lol
-    			teleportAllPlayersOut( getBounds().getyBlockMax() );
+    			teleportAllPlayersOut();
 //    			setStatsTeleport2TimeMS(
 //    					teleportAllPlayersOut( getBounds().getyBlockMax() ) );
         		
@@ -684,7 +690,10 @@ public abstract class MineReset
         		// Broadcast message to all players within a certain radius of this mine:
         		broadcastResetMessageToAllPlayersWithRadius();
 //        		broadcastResetMessageToAllPlayersWithRadius( MINE_RESET__BROADCAST_RADIUS_BLOCKS );
-
+        		
+        		
+        		submitTeleportGlassBlockRemoval();
+        		
                 
                 // Tie to the command stats mode so it logs it if stats are enabled:
                 if ( PrisonMines.getInstance().getMineManager().isMineStats() || 
@@ -742,7 +751,7 @@ public abstract class MineReset
 			if (!canceled) {
 				
 				try {
-					teleportAllPlayersOut( getBounds().getyBlockMax() );
+					teleportAllPlayersOut();
 //					setStatsTeleport1TimeMS(
 //							teleportAllPlayersOut( getBounds().getyBlockMax() ) );
 					

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
@@ -1125,7 +1125,7 @@ public abstract class MineReset
 	public boolean submitMineSweeperTask() {
 		boolean results = false;
 		
-		if ( !isMineSweeperSubmitted() ) {
+		if ( isMineSweeperEnabled() && !isMineSweeperSubmitted() ) {
 			
 			synchronized ( MineSweeperTask.class ) {
 				

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MineChangeBlockTask.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MineChangeBlockTask.java
@@ -1,0 +1,52 @@
+package tech.mcprison.prison.mines.tasks;
+
+import tech.mcprison.prison.internal.block.PrisonBlock;
+import tech.mcprison.prison.tasks.PrisonRunnable;
+import tech.mcprison.prison.util.Location;
+
+public class MineChangeBlockTask
+	implements PrisonRunnable
+{
+	private Location location;
+	private PrisonBlock targetBlock;
+	
+	public MineChangeBlockTask( Location location, PrisonBlock targetBlock ) {
+		super();
+		
+		this.location = location;
+		this.targetBlock = targetBlock;
+	}
+	
+	@Override
+	public void run() {
+		
+    	Location topOfMineLocation = new Location( getLocation() );
+    	topOfMineLocation.setY( topOfMineLocation.getBlockY() - 1 );
+    	
+    	if ( topOfMineLocation.getBlockAt().isEmpty() ) {
+    		// When there is no block under the glass block, spawn in a
+    		// glass block so the player won't fall to their death.
+    		// This block will be within the mine, so it will be replaced
+    		// when the mine resets, or the players can break it too.
+    		
+    		topOfMineLocation.getBlockAt().setPrisonBlock( PrisonBlock.GLASS );
+    	}
+
+		getLocation().getBlockAt().setPrisonBlock( getTargetBlock() );
+		
+	}
+
+	public Location getLocation() {
+		return location;
+	}
+	public void setLocation( Location location ) {
+		this.location = location;
+	}
+
+	public PrisonBlock getTargetBlock() {
+		return targetBlock;
+	}
+	public void setTargetBlock( PrisonBlock targetBlock ) {
+		this.targetBlock = targetBlock;
+	}
+}

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MineTeleportWarmUpTask.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MineTeleportWarmUpTask.java
@@ -17,6 +17,9 @@ public class MineTeleportWarmUpTask
 	
 	private double maxDistance;
 	
+	private String messageSuccess;
+	private String messageFailed;
+	
 	public MineTeleportWarmUpTask( Player player, Mine mine, String target, double maxDistance ) {
 		super();
 		
@@ -27,6 +30,10 @@ public class MineTeleportWarmUpTask
 		this.location = player.getLocation();
 		
 		this.maxDistance = maxDistance;
+		
+		
+		this.messageSuccess = null;
+		this.messageFailed = "&7You moved! Teleport canceled.";
 	}
 	
 	@Override
@@ -39,9 +46,22 @@ public class MineTeleportWarmUpTask
 		
 		if ( bounds.getDistance3d() <= getMaxDistance() ) {
 			mine.teleportPlayerOut( getPlayer(), getTarget() );
+			
+    		// To "move" the player out of the mine, they are elevated by one block above the surface
+    		// so need to remove the glass block if one is spawned under them.  If there is no glass
+    		// block, then it will do nothing.
+    		mine.submitTeleportGlassBlockRemoval();
+
+    		if ( getMessageSuccess() != null && !getMessageSuccess().isEmpty() ) {
+    			
+    			player.sendMessage( getMessageSuccess() );
+    		}
 		}
 		else {
-			player.sendMessage( "&7You moved! Teleport canceled." );
+			if ( getMessageFailed() != null && !getMessageFailed().isEmpty() ) {
+				
+				player.sendMessage( getMessageFailed() );
+			}
 		}
 		
 	}
@@ -79,5 +99,19 @@ public class MineTeleportWarmUpTask
 	}
 	public void setMaxDistance( double maxDistance ) {
 		this.maxDistance = maxDistance;
+	}
+
+	public String getMessageSuccess() {
+		return messageSuccess;
+	}
+	public void setMessageSuccess( String messageSuccess ) {
+		this.messageSuccess = messageSuccess;
+	}
+
+	public String getMessageFailed() {
+		return messageFailed;
+	}
+	public void setMessageFailed( String messageFailed ) {
+		this.messageFailed = messageFailed;
 	}
 }

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MineTeleportWarmUpTask.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MineTeleportWarmUpTask.java
@@ -37,7 +37,7 @@ public class MineTeleportWarmUpTask
 		
 		Bounds bounds = new Bounds( getLocation(), locationNew );
 		
-		if ( bounds.getDistance() <= getMaxDistance() ) {
+		if ( bounds.getDistance3d() <= getMaxDistance() ) {
 			mine.teleportPlayerOut( getPlayer(), getTarget() );
 		}
 		else {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MineTeleportWarmUpTask.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MineTeleportWarmUpTask.java
@@ -1,0 +1,83 @@
+package tech.mcprison.prison.mines.tasks;
+
+import tech.mcprison.prison.internal.Player;
+import tech.mcprison.prison.mines.data.Mine;
+import tech.mcprison.prison.tasks.PrisonRunnable;
+import tech.mcprison.prison.util.Bounds;
+import tech.mcprison.prison.util.Location;
+
+public class MineTeleportWarmUpTask
+	implements PrisonRunnable
+{
+	private Player player;
+	private Mine mine;
+	private String target;
+	
+	private Location location;
+	
+	private double maxDistance;
+	
+	public MineTeleportWarmUpTask( Player player, Mine mine, String target, double maxDistance ) {
+		super();
+		
+		this.player = player;
+		this.mine = mine;
+		this.target = target;
+		
+		this.location = player.getLocation();
+		
+		this.maxDistance = maxDistance;
+	}
+	
+	@Override
+	public void run() {
+		
+		
+		Location locationNew = getPlayer().getLocation();
+		
+		Bounds bounds = new Bounds( getLocation(), locationNew );
+		
+		if ( bounds.getDistance() <= getMaxDistance() ) {
+			mine.teleportPlayerOut( getPlayer(), getTarget() );
+		}
+		else {
+			player.sendMessage( "&7You moved! Teleport canceled." );
+		}
+		
+	}
+
+	public Player getPlayer() {
+		return player;
+	}
+	public void setPlayer( Player player ) {
+		this.player = player;
+	}
+
+	public Mine getMine() {
+		return mine;
+	}
+	public void setMine( Mine mine ) {
+		this.mine = mine;
+	}
+
+	public String getTarget() {
+		return target;
+	}
+	public void setTarget( String target ) {
+		this.target = target;
+	}
+
+	public Location getLocation() {
+		return location;
+	}
+	public void setLocation( Location location ) {
+		this.location = location;
+	}
+
+	public double getMaxDistance() {
+		return maxDistance;
+	}
+	public void setMaxDistance( double maxDistance ) {
+		this.maxDistance = maxDistance;
+	}
+}

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RankUpCommand.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RankUpCommand.java
@@ -39,6 +39,7 @@ import tech.mcprison.prison.ranks.data.Rank;
 import tech.mcprison.prison.ranks.data.RankLadder;
 import tech.mcprison.prison.ranks.data.RankPlayer;
 import tech.mcprison.prison.ranks.managers.LadderManager;
+import tech.mcprison.prison.ranks.managers.PlayerManager;
 
 /**
  * The commands for this module.
@@ -376,23 +377,45 @@ public class RankUpCommand
 
 
     @Command(identifier = "ranks set rank", description = "Sets a player to a specified rank on a ladder, " +
-    		"or remove a player from a ladder (delete player rank).", 
+    		"or remove a player from a ladder (delete player rank).  Or if you use '*all*' for player name, " +
+    		"then it will run this command on all players registered with Prison. When *all* is combined with " +
+    		"the rankName '*same*' it will reapply the same rank to each player which will rerun the rank " +
+    		"commands for the players.  If rank 'A' is your starting rank, you can use '*all*' and 'A' to " +
+    		"reset all players to the starting rank; next you will need to -remove- all prestige ladders " +
+    		"from all players too.", 
     			permissions = "ranks.setrank", onlyPlayers = false) 
     public void setRank(CommandSender sender,
-    	@Arg(name = "playerName", def = "", description = "Player name") String playerName,
-    	@Arg(name = "rankName", description = "The rank to assign to the player, or [-remove-] " +
+    	@Arg(name = "playerName", def = "", description = "Player name, or [*all*]") String playerName,
+    	@Arg(name = "rankName", description = "The rank to assign to the player, or [-remove-, *same*] " +
     						"to deleete the player from the rank.") String rank,
         @Arg(name = "ladder", description = "The ladder to demote on.", def = "default") String ladder) {
 
-    	Player player = getPlayer( sender, playerName );
-    	
-    	if (player == null) {
-    		sender.sendMessage( "&3You must be a player in the game to run this command, " +
-    										"and/or the player must be online." );
-    		return;
+    	if ( "*all*".equalsIgnoreCase( playerName )) {
+    		PlayerManager pm = PrisonRanks.getInstance().getPlayerManager();
+    		
+    		for ( RankPlayer player : pm.getPlayers() ) {
+    			
+    			Player targetPlayer = getPlayer( null, player.getName() );
+    			if ( targetPlayer != null ) {
+    				
+    				String targetRank = rank.equalsIgnoreCase("*same*") ? player.getRank( ladder ).getName() : rank;
+    				setPlayerRank( targetPlayer, targetRank, ladder, sender );
+    			}
+    		}
+    		
     	}
-
-        setPlayerRank( player, rank, ladder, sender );
+    	else {
+    		
+    		Player player = getPlayer( sender, playerName );
+    		
+    		if (player == null) {
+    			sender.sendMessage( "&3You must be a player in the game to run this command, " +
+    					"and/or the player must be online." );
+    			return;
+    		}
+    		
+    		setPlayerRank( player, rank, ladder, sender );
+    	}
     }
 
     

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
@@ -630,10 +630,13 @@ public class RanksCommands
 
     }
 
-    @Command(identifier = "ranks info", description = "Information about a rank.", 
+    @Command(identifier = "ranks info", description = "Information about a rank.  Use of the option of 'ALL' then " +
+    							"rank commands will be included too.", 
     							onlyPlayers = false, permissions = "ranks.info", 
     							altPermissions = "ranks.admin" )
-    public void infoCmd(CommandSender sender, @Arg(name = "rankName") String rankName) {
+    public void infoCmd(CommandSender sender, 
+    		@Arg(name = "rankName") String rankName, 
+    		@Arg(name = "options", def = "", description = "Optional: ['ALL'] will include rank commands.") String options) {
     	
         Rank rank = PrisonRanks.getInstance().getRankManager().getRank(rankName);
         if ( rank == null ) {
@@ -699,6 +702,11 @@ public class RanksCommands
         }
 
         display.send(sender);
+        
+        if ( options != null && "all".equalsIgnoreCase( options )) {
+        	
+        	getRankCommandCommands().commandList( sender, rankName );
+        }
     }
 
     // set commands

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/managers/PlayerManager.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/managers/PlayerManager.java
@@ -649,10 +649,14 @@ public class PlayerManager
     					double balance = getPlayerBalance(prisonPlayer,rank);
     					
     					double remaining = cost - balance;
-    					
-//    					if ( remaining < 0 ) {
-//    						remaining = 0;
-//    					}
+    
+    					// Without the following, if the player has more money than what the rank will cost,
+    					// then it would result in a negative amount, which is wrong.  
+    					// This is cost remaining... once they are able to afford a rankup, then remaining 
+    					// cost will be zero.
+    					if ( remaining < 0 ) {
+    						remaining = 0;
+    					}
     					
         				if ( attribute != null && attribute instanceof PlaceholderAttributeNumberFormat ) {
         					PlaceholderAttributeNumberFormat attributeNF = 

--- a/prison-spigot/build.gradle
+++ b/prison-spigot/build.gradle
@@ -30,12 +30,32 @@ repositories {
     maven { url = "https://repo.lucko.me/" }
     maven { url = "https://repo.codemc.org/repository/maven-public/" }
     //maven { url = "https://repo.inventivetalent.org/content/groups/public/" }
-    maven { url = "http://repo.mvdw-software.be/content/groups/public/" }
-    maven { url = 'http://repo.extendedclip.com/content/repositories/placeholderapi/' }
-    maven { url = 'https://mvnrepository.com/artifact/org.apache.commons/commons-lang3' }
+    maven { 
+    	url = "http://repo.mvdw-software.be/content/groups/public/" 
+    	content {
+    		includeGroup 'be.maximvdw'
+    	}
+    }
+    maven { 
+    	url = 'http://repo.extendedclip.com/content/repositories/placeholderapi/' 
+    	content {
+    		includeGroup 'me.lucko.luckperms'
+    	}
+    }
+    maven { 
+    	url = 'https://mvnrepository.com/artifact/org.apache.commons/commons-lang3' 
+    	content {
+    		includeGroup 'org.apache.commons'
+    	}
+    }
    // maven { url = 'https://repo.pcgamingfreaks.at/repository/maven-everything' }
     
-    maven { url = 'https://mvnrepository.com/artifact/com.github.cryptomorin' }
+    maven { 
+    	url = 'https://mvnrepository.com/artifact/com.github.cryptomorin' 
+    	content {
+    		includeGroup 'com.github.cryptomorin'
+    	}
+    }
   //  maven { url = 'https://maven.enginehub.org/repo/' }
   
   	//maven { url = "https://nexus.badbones69.com/repository/maven-releases/" }
@@ -58,6 +78,7 @@ dependencies {
     
 	implementation 'org.apache.commons:commons-lang3:3.9'
     implementation 'me.clip:placeholderapi:2.9.1'
+//    implementation 'me.clip:placeholderapi:2.10.9'
     
     implementation 'net.luckperms:api:5.0'
     implementation 'me.lucko.luckperms:luckperms-api:4.0'

--- a/prison-spigot/build.gradle
+++ b/prison-spigot/build.gradle
@@ -30,6 +30,7 @@ repositories {
     maven { url = "https://repo.lucko.me/" }
     maven { url = "https://repo.codemc.org/repository/maven-public/" }
     //maven { url = "https://repo.inventivetalent.org/content/groups/public/" }
+    
     maven { 
     	url = "http://repo.mvdw-software.be/content/groups/public/" 
     	content {
@@ -37,9 +38,10 @@ repositories {
     	}
     }
     maven { 
-    	url = 'http://repo.extendedclip.com/content/repositories/placeholderapi/' 
+    	url = 'https://repo.extendedclip.com/content/repositories/placeholderapi/' 
+    	//url = 'http://repo.extendedclip.com/content/repositories/placeholderapi/' 
     	content {
-    		includeGroup 'me.lucko.luckperms'
+    		includeGroup 'me.clip'
     	}
     }
     maven { 
@@ -77,8 +79,9 @@ dependencies {
     // Using jar instead: lib/Spiget_v1.4.2.prison-build.jar
     
 	implementation 'org.apache.commons:commons-lang3:3.9'
+
     implementation 'me.clip:placeholderapi:2.9.1'
-//    implementation 'me.clip:placeholderapi:2.10.9'
+//  implementation 'me.clip:placeholderapi:2.10.9'
     
     implementation 'net.luckperms:api:5.0'
     implementation 'me.lucko.luckperms:luckperms-api:4.0'
@@ -166,7 +169,10 @@ shadowJar {
         include(dependency('org.apache.commons:commons-lang3:3.10'))
         include(dependency('com.google.code.gson:gson:2.8.6'))
         include(dependency('org.bstats:bstats-bukkit:1.5'))
+
         include(dependency('me.clip:placeholderapi:2.9.1'))
+//        include(dependency('me.clip:placeholderapi:2.10.9'))
+
         //include(dependency('org.inventivetalent.spiget-update:bukkit:1.4.2-SNAPSHOT'))
         include(dependency('com.github.cryptomorin:XSeries:7.8.0'))
         

--- a/prison-spigot/build.gradle
+++ b/prison-spigot/build.gradle
@@ -80,8 +80,8 @@ dependencies {
     
 	implementation 'org.apache.commons:commons-lang3:3.9'
 
-    implementation 'me.clip:placeholderapi:2.9.1'
-//  implementation 'me.clip:placeholderapi:2.10.9'
+//    implementation 'me.clip:placeholderapi:2.9.1'
+    implementation 'me.clip:placeholderapi:2.10.9'
     
     implementation 'net.luckperms:api:5.0'
     implementation 'me.lucko.luckperms:luckperms-api:4.0'
@@ -170,8 +170,8 @@ shadowJar {
         include(dependency('com.google.code.gson:gson:2.8.6'))
         include(dependency('org.bstats:bstats-bukkit:1.5'))
 
-        include(dependency('me.clip:placeholderapi:2.9.1'))
-//        include(dependency('me.clip:placeholderapi:2.10.9'))
+        //include(dependency('me.clip:placeholderapi:2.9.1'))
+        include(dependency('me.clip:placeholderapi:2.10.9'))
 
         //include(dependency('org.inventivetalent.spiget-update:bukkit:1.4.2-SNAPSHOT'))
         include(dependency('com.github.cryptomorin:XSeries:7.8.0'))

--- a/prison-spigot/build.gradle
+++ b/prison-spigot/build.gradle
@@ -24,10 +24,18 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
+    jcenter()
+
+	// net.luckperm.api:
     maven { url = "https://hub.spigotmc.org/nexus/content/groups/public" }
+
+    // The following houses many repos, so don't limit to just luckperms:
+    // net.milkbowl, be.maximvdw, org.bstats:bstats-bukkit
+    maven { url = "https://repo.lucko.me/" }
+
     maven { url = "https://oss.sonatype.org/content/repositories/snapshots/" }
     maven { url = "http://nexus.hc.to/content/repositories/pub_releases" }
-    maven { url = "https://repo.lucko.me/" }
+    
     maven { url = "https://repo.codemc.org/repository/maven-public/" }
     //maven { url = "https://repo.inventivetalent.org/content/groups/public/" }
     
@@ -62,7 +70,6 @@ repositories {
   
   	//maven { url = "https://nexus.badbones69.com/repository/maven-releases/" }
   	
-    jcenter()
 }
 
 
@@ -71,7 +78,9 @@ dependencies {
     implementation project(':prison-core')
     implementation project(':prison-mines')
     implementation project(':prison-ranks')
-    
+
+// NOTE: source code changes for v1.7    
+//    implementation 'org.bstats:bstats-bukkit:1.7'
     implementation 'org.bstats:bstats-bukkit:1.5'
     
     // Repo keeps going down:
@@ -80,13 +89,16 @@ dependencies {
     
 	implementation 'org.apache.commons:commons-lang3:3.9'
 
-//    implementation 'me.clip:placeholderapi:2.9.1'
     implementation 'me.clip:placeholderapi:2.10.9'
     
+    // Repo may be hosted: https://hub.spigotmc.org/nexus/content/groups/public/
+    // But do not see v5.0
     implementation 'net.luckperms:api:5.0'
-    implementation 'me.lucko.luckperms:luckperms-api:4.0'
     
-	implementation 'com.github.cryptomorin:XSeries:7.8.0'
+    implementation 'me.lucko.luckperms:luckperms-api:4.2'
+    
+	implementation 'com.github.cryptomorin:XSeries:7.9.1.1'
+//	implementation 'com.github.cryptomorin:XSeries:7.8.0'
 //	implementation 'com.github.cryptomorin:XSeries:7.6.0.0.1'
 //	implementation 'com.github.cryptomorin:XSeries:7.5.4'
 //	implementation 'com.github.cryptomorin:XSeries:7.2.1'
@@ -108,10 +120,15 @@ dependencies {
 //	compileOnly 'at.pcgamingfreaks:Minepacks-API:2.3.22'
 //  compileOnly 'at.pcgamingfreaks:Minepacks-API:2.3.21.3'
 
-    compileOnly 'net.milkbowl.vault:VaultAPI:1.6'
-    compileOnly('be.maximvdw:MVdWPlaceholderAPI:2.4.0-SNAPSHOT'){
+    compileOnly 'net.milkbowl.vault:VaultAPI:1.7'
+//    compileOnly 'net.milkbowl.vault:VaultAPI:1.6'
+    
+    compileOnly('be.maximvdw:MVdWPlaceholderAPI:2.5.2-SNAPSHOT'){
         exclude group: 'org.spigotmc'
     }
+//   compileOnly('be.maximvdw:MVdWPlaceholderAPI:2.4.0-SNAPSHOT'){
+//        exclude group: 'org.spigotmc'
+//    }
 
  //   compileOnly 'com.sk89q.worldguard:worldguard-bukkit:7.0.1'
  
@@ -170,11 +187,10 @@ shadowJar {
         include(dependency('com.google.code.gson:gson:2.8.6'))
         include(dependency('org.bstats:bstats-bukkit:1.5'))
 
-        //include(dependency('me.clip:placeholderapi:2.9.1'))
         include(dependency('me.clip:placeholderapi:2.10.9'))
 
         //include(dependency('org.inventivetalent.spiget-update:bukkit:1.4.2-SNAPSHOT'))
-        include(dependency('com.github.cryptomorin:XSeries:7.8.0'))
+        include(dependency('com.github.cryptomorin:XSeries:7.9.1.1'))
         
         //include(dependency('me.badbones69:crazyenchantments-plugin:1.8-Dev-Build-v8'))
         

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -87,7 +87,7 @@ import tech.mcprison.prison.spigot.game.SpigotWorld;
 import tech.mcprison.prison.spigot.placeholder.SpigotPlaceholders;
 import tech.mcprison.prison.spigot.scoreboard.SpigotScoreboardManager;
 import tech.mcprison.prison.spigot.sellall.SellAllBlockData;
-import tech.mcprison.prison.spigot.sellall.SellAllPrisonCommands;
+import tech.mcprison.prison.spigot.commands.SellAllPrisonCommands;
 import tech.mcprison.prison.spigot.util.ActionBarUtil;
 import tech.mcprison.prison.spigot.util.SpigotYamlFileIO;
 import tech.mcprison.prison.store.Storage;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -826,7 +826,7 @@ public class SpigotPlatform
 			}
 			catch ( NumberFormatException e ) {
 				Output.get().logInfo( "Invalid config.yml value. The setting " +
-						"%s should be an integer but had a value of [%s]", 
+						"%s should be an long but had a value of [%s]", 
 						key, config );
 			}
 			
@@ -835,6 +835,28 @@ public class SpigotPlatform
 		return results;
 	}
 	
+	
+	@Override
+	public double getConfigDouble( String key, double defaultValue ) {
+		double results = defaultValue;
+		
+		String config = getConfigString(key);
+		
+		if ( config != null && config.trim().length() > 0) {
+			
+			try {
+				results = Double.parseDouble( config );
+			}
+			catch ( NumberFormatException e ) {
+				Output.get().logInfo( "Invalid config.yml value. The setting " +
+						"%s should be an double but had a value of [%s]", 
+						key, config );
+			}
+			
+		}
+		
+		return results;
+	}
 
 	
     /**

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -774,6 +774,14 @@ public class SpigotPlatform
 		return ( val != null && val.trim().equalsIgnoreCase( "true" ) );
 	}
 	
+	
+	@Override
+	public boolean isUseNewPrisonBlockModel() {
+		
+		return getConfigBooleanFalse( "use-new-prison-block-model" );
+//		return !getConfigBooleanFalse( "use-old-prison-block-model" );
+	}
+	
 	/**
 	 * <p>This returns the boolean value that is associated with the key.
 	 * It has to match on true to return a true value, but if the key does
@@ -1242,7 +1250,7 @@ public class SpigotPlatform
 		
 		
 		
-        if ( Prison.get().getPlatform().getConfigBooleanFalse( "use-new-prison-block-model" ) ) {
+        if ( Prison.get().getPlatform().isUseNewPrisonBlockModel() ) {
         	
         	for ( SellAllBlockData xMatCost : buildBlockListXMaterial() ) {
         		
@@ -1292,7 +1300,7 @@ public class SpigotPlatform
 			for ( int i = 0; i < mBlocks.size(); i++ )
 			{
 				
-				if ( Prison.get().getPlatform().getConfigBooleanFalse( "use-new-prison-block-model" ) ) {
+				if ( Prison.get().getPlatform().isUseNewPrisonBlockModel() ) {
 					
 					PrisonBlock prisonBlock = Prison.get().getPlatform().getPrisonBlock( mBlocks.get( i ) );
 	            	if ( prisonBlock != null ) {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -87,7 +87,7 @@ import tech.mcprison.prison.spigot.game.SpigotWorld;
 import tech.mcprison.prison.spigot.placeholder.SpigotPlaceholders;
 import tech.mcprison.prison.spigot.scoreboard.SpigotScoreboardManager;
 import tech.mcprison.prison.spigot.sellall.SellAllBlockData;
-import tech.mcprison.prison.spigot.commands.SellAllPrisonCommands;
+import tech.mcprison.prison.spigot.commands.PrisonSpigotSellAllCommands;
 import tech.mcprison.prison.spigot.util.ActionBarUtil;
 import tech.mcprison.prison.spigot.util.SpigotYamlFileIO;
 import tech.mcprison.prison.store.Storage;
@@ -1229,8 +1229,8 @@ public class SpigotPlatform
 		SpigotPrison.getInstance().getConfig().set( "sellall", true );
 		
 		
-		SellAllPrisonCommands sellall = SellAllPrisonCommands.get();
-		if ( sellall != null && SellAllPrisonCommands.isEnabled()) {
+		PrisonSpigotSellAllCommands sellall = PrisonSpigotSellAllCommands.get();
+		if ( sellall != null && PrisonSpigotSellAllCommands.isEnabled()) {
 			
 			// Setup all the prices in sellall:
 			for ( SellAllBlockData xMatCost : buildBlockListXMaterial() ) {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
@@ -178,7 +178,7 @@ public class SpigotPrison extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new SpigotListener(), this);
 
         try {
-            isBackPacksEnabled = getInstance().getConfig().getString("backpacks").equalsIgnoreCase("true");
+            isBackPacksEnabled = getConfig().getString("backpacks").equalsIgnoreCase("true");
         } catch (NullPointerException ignored){}
 
         if (isBackPacksEnabled){

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
@@ -178,7 +178,7 @@ public class SpigotPrison extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new SpigotListener(), this);
 
         try {
-            isBackPacksEnabled = getConfig().getString("backpacks").equalsIgnoreCase("true");
+            isBackPacksEnabled = getConfig().getBoolean("backpacks");
         } catch (NullPointerException ignored){}
 
         if (isBackPacksEnabled){

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
@@ -79,7 +79,7 @@ import tech.mcprison.prison.spigot.permissions.LuckPerms5;
 import tech.mcprison.prison.spigot.permissions.VaultPermissions;
 import tech.mcprison.prison.spigot.placeholder.MVdWPlaceholderIntegration;
 import tech.mcprison.prison.spigot.placeholder.PlaceHolderAPIIntegration;
-import tech.mcprison.prison.spigot.sellall.SellAllPrisonCommands;
+import tech.mcprison.prison.spigot.commands.SellAllPrisonCommands;
 import tech.mcprison.prison.spigot.slime.SlimeBlockFunEventListener;
 import tech.mcprison.prison.spigot.spiget.BluesSpigetSemVerComparator;
 import tech.mcprison.prison.spigot.utils.PrisonUtilsModule;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
@@ -79,7 +79,7 @@ import tech.mcprison.prison.spigot.permissions.LuckPerms5;
 import tech.mcprison.prison.spigot.permissions.VaultPermissions;
 import tech.mcprison.prison.spigot.placeholder.MVdWPlaceholderIntegration;
 import tech.mcprison.prison.spigot.placeholder.PlaceHolderAPIIntegration;
-import tech.mcprison.prison.spigot.commands.SellAllPrisonCommands;
+import tech.mcprison.prison.spigot.commands.PrisonSpigotSellAllCommands;
 import tech.mcprison.prison.spigot.slime.SlimeBlockFunEventListener;
 import tech.mcprison.prison.spigot.spiget.BluesSpigetSemVerComparator;
 import tech.mcprison.prison.spigot.utils.PrisonUtilsModule;
@@ -517,8 +517,8 @@ public class SpigotPrison extends JavaPlugin {
 //        }
 
         // Load sellAll if enabled
-        if (SellAllPrisonCommands.isEnabled()){
-            Prison.get().getCommandHandler().registerCommands(new SellAllPrisonCommands());
+        if (PrisonSpigotSellAllCommands.isEnabled()){
+            Prison.get().getCommandHandler().registerCommands(new PrisonSpigotSellAllCommands());
         }
 
         // Load backpacks commands if enabled

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/api/PrisonSpigotAPI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/api/PrisonSpigotAPI.java
@@ -128,7 +128,7 @@ public class PrisonSpigotAPI {
 	public String getPrisonBlockName( String blockName ) {
 		String results = null;
 		
-        if ( Prison.get().getPlatform().getConfigBooleanFalse( "use-new-prison-block-model" ) ) {
+        if ( Prison.get().getPlatform().isUseNewPrisonBlockModel() ) {
         	
         	PrisonBlock prisonBlock = Prison.get().getPlatform().getPrisonBlock( blockName );
         	if ( prisonBlock != null && prisonBlock.isBlock() ) {
@@ -161,7 +161,7 @@ public class PrisonSpigotAPI {
 			PrisonBlock prisonBlock = null;
 			BlockType blockType = null;
 			
-			if ( Prison.get().getPlatform().getConfigBooleanFalse( "use-new-prison-block-model" ) ) {
+			if ( Prison.get().getPlatform().isUseNewPrisonBlockModel() ) {
 				
 				prisonBlock = Prison.get().getPlatform().getPrisonBlock( prisonBlockName );
 				if ( prisonBlock != null && !prisonBlock.isBlock() ) {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/api/PrisonSpigotAPI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/api/PrisonSpigotAPI.java
@@ -24,7 +24,6 @@ import tech.mcprison.prison.ranks.managers.RankManager;
 import tech.mcprison.prison.spigot.SpigotPrison;
 import tech.mcprison.prison.spigot.backpacks.BackpacksUtil;
 import tech.mcprison.prison.spigot.block.SpigotBlock;
-import tech.mcprison.prison.spigot.sellall.SellAllPrisonCommands;
 import tech.mcprison.prison.spigot.game.SpigotPlayer;
 import tech.mcprison.prison.spigot.sellall.SellAllUtil;
 import tech.mcprison.prison.util.BlockType;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
@@ -468,12 +468,12 @@ public class AutoManagerFeatures
 			if ( isBoolean( AutoFeatures.isAutoSellPerBlockBreakInlinedEnabled ) ) {
 				// run sellall inline with the block break event:
 				if (SellAllPrisonCommands.get() != null) {
-					SellAllPrisonCommands.get().sellAllSellCommand(new SpigotPlayer(player));
+					SellAllPrisonCommands.get().sellAllSellCommand(new SpigotPlayer(player), "silent");
 				}
 			}
 			else {
 				// Submit sellall to run in the future (0 ticks in the future):
-				String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "sellall sell" );
+				String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "sellall sell silent" );
 				Bukkit.dispatchCommand(player, registeredCmd);
 			}
 		}
@@ -653,7 +653,7 @@ public class AutoManagerFeatures
 										SpigotPrison.getInstance().getMessagesConfig().getString("Message.SellAllAutoSell")));
 							}
 							
-							SellAllPrisonCommands.get().sellAllSellCommand( new SpigotPlayer( player ) );
+							SellAllPrisonCommands.get().sellAllSellCommand( new SpigotPlayer( player ), "" );
 							
 //							String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "sellall sell" );
 //							Bukkit.dispatchCommand(player, registeredCmd);
@@ -664,7 +664,7 @@ public class AutoManagerFeatures
 						Output.get().sendInfo(new SpigotPlayer(player), SpigotPrison.format(
 								SpigotPrison.getInstance().getMessagesConfig().getString("Message.SellAllAutoSell")));
 					}
-					SellAllPrisonCommands.get().sellAllSellCommand( new SpigotPlayer( player ) );
+					SellAllPrisonCommands.get().sellAllSellCommand( new SpigotPlayer( player ), "" );
 
 //					String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "sellall sell" );
 //					Bukkit.dispatchCommand(player, registeredCmd);

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
@@ -37,7 +37,7 @@ import tech.mcprison.prison.spigot.block.OnBlockBreakEventCore;
 import tech.mcprison.prison.spigot.block.SpigotBlock;
 import tech.mcprison.prison.spigot.block.SpigotItemStack;
 import tech.mcprison.prison.spigot.game.SpigotPlayer;
-import tech.mcprison.prison.spigot.sellall.SellAllPrisonCommands;
+import tech.mcprison.prison.spigot.commands.SellAllPrisonCommands;
 import tech.mcprison.prison.spigot.spiget.BluesSpigetSemVerComparator;
 import tech.mcprison.prison.util.BlockType;
 import tech.mcprison.prison.util.Text;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
@@ -468,7 +468,7 @@ public class AutoManagerFeatures
 			if ( isBoolean( AutoFeatures.isAutoSellPerBlockBreakInlinedEnabled ) ) {
 				// run sellall inline with the block break event:
 				if (PrisonSpigotSellAllCommands.get() != null) {
-					PrisonSpigotSellAllCommands.get().sellAllSellCommand(new SpigotPlayer(player), "silent");
+					PrisonSpigotSellAllCommands.get().sellAllSellWithDelayCommand(new SpigotPlayer(player));
 				}
 			}
 			else {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
@@ -37,7 +37,7 @@ import tech.mcprison.prison.spigot.block.OnBlockBreakEventCore;
 import tech.mcprison.prison.spigot.block.SpigotBlock;
 import tech.mcprison.prison.spigot.block.SpigotItemStack;
 import tech.mcprison.prison.spigot.game.SpigotPlayer;
-import tech.mcprison.prison.spigot.commands.SellAllPrisonCommands;
+import tech.mcprison.prison.spigot.commands.PrisonSpigotSellAllCommands;
 import tech.mcprison.prison.spigot.spiget.BluesSpigetSemVerComparator;
 import tech.mcprison.prison.util.BlockType;
 import tech.mcprison.prison.util.Text;
@@ -467,8 +467,8 @@ public class AutoManagerFeatures
 			// Run sell all
 			if ( isBoolean( AutoFeatures.isAutoSellPerBlockBreakInlinedEnabled ) ) {
 				// run sellall inline with the block break event:
-				if (SellAllPrisonCommands.get() != null) {
-					SellAllPrisonCommands.get().sellAllSellCommand(new SpigotPlayer(player), "silent");
+				if (PrisonSpigotSellAllCommands.get() != null) {
+					PrisonSpigotSellAllCommands.get().sellAllSellCommand(new SpigotPlayer(player), "silent");
 				}
 			}
 			else {
@@ -653,7 +653,7 @@ public class AutoManagerFeatures
 										SpigotPrison.getInstance().getMessagesConfig().getString("Message.SellAllAutoSell")));
 							}
 							
-							SellAllPrisonCommands.get().sellAllSellCommand( new SpigotPlayer( player ), "" );
+							PrisonSpigotSellAllCommands.get().sellAllSellCommand( new SpigotPlayer( player ), "" );
 							
 //							String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "sellall sell" );
 //							Bukkit.dispatchCommand(player, registeredCmd);
@@ -664,7 +664,7 @@ public class AutoManagerFeatures
 						Output.get().sendInfo(new SpigotPlayer(player), SpigotPrison.format(
 								SpigotPrison.getInstance().getMessagesConfig().getString("Message.SellAllAutoSell")));
 					}
-					SellAllPrisonCommands.get().sellAllSellCommand( new SpigotPlayer( player ), "" );
+					PrisonSpigotSellAllCommands.get().sellAllSellCommand( new SpigotPlayer( player ), "" );
 
 //					String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "sellall sell" );
 //					Bukkit.dispatchCommand(player, registeredCmd);

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksListeners.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksListeners.java
@@ -39,7 +39,6 @@ public class BackpacksListeners implements Listener {
     @EventHandler
     public void onPlayerBackpackEdit(InventoryClickEvent e){
         backpackEditEvent(e);
-
     }
 
     @EventHandler

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
@@ -41,7 +41,7 @@ public class BackpacksUtil {
     public static List<String> openBackpacks = new ArrayList<>();
     public static List<String> backpackEdited = new ArrayList<>();
     private final Compatibility compat = SpigotPrison.getInstance().getCompatibility();
-    private int backpackDefaultSize = Integer.parseInt(backpacksConfig.getString("Options.BackPack_Default_Size"));
+    private final int backpackDefaultSize = Integer.parseInt(backpacksConfig.getString("Options.BackPack_Default_Size"));
 
     /**
      * Check if Backpacks's enabled.
@@ -83,9 +83,11 @@ public class BackpacksUtil {
 
     /**
      * Check if player reached limit of own backpacks.
+     *
+     * @return boolean - True if reached, false if not.
      * */
     public boolean reachedBackpacksLimit(Player p){
-        return getBoolean(BackpacksUtil.get().getBackpacksConfig().getString("Options.Multiple-BackPacks-For-Player-Enabled")) && (Integer.parseInt(BackpacksUtil.get().getBackpacksConfig().getString("Options.Multiple-BackPacks-For-Player")) <= BackpacksUtil.get().getNumberOwnedBackpacks(p));
+        return getBoolean(backpacksConfig.getString("Options.Multiple-BackPacks-For-Player-Enabled")) && (Integer.parseInt(backpacksConfig.getString("Options.Multiple-BackPacks-For-Player")) <= getNumberOwnedBackpacks(p));
     }
 
     /**
@@ -635,7 +637,7 @@ public class BackpacksUtil {
     private boolean checkOwnBackpack(Player p) {
         updateCachedBackpack();
 
-        String playerName = backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items.Playername");
+        String playerName = backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items.Playername");
         return playerName != null;
     }
 
@@ -671,7 +673,7 @@ public class BackpacksUtil {
 
         try {
             try {
-                backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items", null);
+                backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items", null);
                 backpacksDataConfig.save(backpacksFile);
             } catch (NullPointerException ex){
                 return false;
@@ -690,7 +692,7 @@ public class BackpacksUtil {
 
         try {
             try {
-                backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id, null);
+                backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id, null);
                 backpacksDataConfig.save(backpacksFile);
             } catch (NullPointerException ex){
                 return false;
@@ -709,7 +711,7 @@ public class BackpacksUtil {
 
         try {
             try {
-                backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items", null);
+                backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items", null);
                 backpacksDataConfig.save(backpacksFile);
             } catch (NullPointerException ex){
                 return false;
@@ -728,7 +730,7 @@ public class BackpacksUtil {
 
         try {
             try {
-                backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id, null);
+                backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id, null);
                 backpacksDataConfig.save(backpacksFile);
             } catch (NullPointerException ex){
                 return false;
@@ -752,7 +754,7 @@ public class BackpacksUtil {
 
         updateCachedBackpack();
 
-        backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items.Size", size);
+        backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items.Size", size);
 
         try {
             backpacksDataConfig.save(backpacksFile);
@@ -772,7 +774,7 @@ public class BackpacksUtil {
 
         updateCachedBackpack();
 
-        backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items.Size", size);
+        backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items.Size", size);
 
         try {
             backpacksDataConfig.save(backpacksFile);
@@ -792,7 +794,7 @@ public class BackpacksUtil {
 
         updateCachedBackpack();
 
-        backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".Size", size);
+        backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id + ".Size", size);
 
         try {
             backpacksDataConfig.save(backpacksFile);
@@ -812,7 +814,7 @@ public class BackpacksUtil {
 
         updateCachedBackpack();
 
-        backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".Size", size);
+        backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id + ".Size", size);
 
         try {
             backpacksDataConfig.save(backpacksFile);
@@ -846,7 +848,7 @@ public class BackpacksUtil {
         }
 
         try {
-            backPackSize = Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".Size"));
+            backPackSize = Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items-" + id + ".Size"));
         } catch (NumberFormatException ignored){}
 
         return getBackpackPermSize(p, backPackSize);
@@ -879,13 +881,13 @@ public class BackpacksUtil {
         // Get the Items config section
         Set<String> slots;
         try {
-            slots = backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId().toString() + ".Items").getKeys(false);
+            slots = backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId() + ".Items").getKeys(false);
         } catch (NullPointerException ex){
             return inv;
         }
         if (slots.size() != 0) {
             for (String slot : slots) {
-                ItemStack finalItem = backpacksDataConfig.getItemStack("Inventories." + p.getUniqueId().toString() + ".Items." + slot + ".ITEMSTACK");
+                ItemStack finalItem = backpacksDataConfig.getItemStack("Inventories." + p.getUniqueId() + ".Items." + slot + ".ITEMSTACK");
                 if (finalItem != null) {
                     int slotNumber = Integer.parseInt(slot);
                     if (size > slotNumber) {
@@ -907,13 +909,13 @@ public class BackpacksUtil {
         // Get the Items config section
         Set<String> slots;
         try {
-            slots = backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId().toString() + ".Items-" + id).getKeys(false);
+            slots = backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId() + ".Items-" + id).getKeys(false);
         } catch (NullPointerException ex){
             return inv;
         }
         if (slots.size() != 0) {
             for (String slot : slots) {
-                ItemStack finalItem = backpacksDataConfig.getItemStack("Inventories." + p.getUniqueId().toString() + ".Items-" + id + "." + slot + ".ITEMSTACK");
+                ItemStack finalItem = backpacksDataConfig.getItemStack("Inventories." + p.getUniqueId() + ".Items-" + id + "." + slot + ".ITEMSTACK");
                 if (finalItem != null) {
                     int slotNumber = Integer.parseInt(slot);
                     if (size > slotNumber) {
@@ -948,13 +950,13 @@ public class BackpacksUtil {
         // Get the Items config section
         Set<String> slots;
         try {
-            slots = backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId().toString() + ".Items").getKeys(false);
+            slots = backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId() + ".Items").getKeys(false);
         } catch (NullPointerException ex){
             return inv;
         }
         if (slots.size() != 0) {
             for (String slot : slots) {
-                ItemStack finalItem = backpacksDataConfig.getItemStack("Inventories." + p.getUniqueId().toString() + ".Items." + slot + ".ITEMSTACK");
+                ItemStack finalItem = backpacksDataConfig.getItemStack("Inventories." + p.getUniqueId() + ".Items." + slot + ".ITEMSTACK");
                 if (finalItem != null) {
                     try {
                         inv.setItem(Integer.parseInt(slot), finalItem);
@@ -982,7 +984,7 @@ public class BackpacksUtil {
             int slot = 0;
 
             try {
-                backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items", null);
+                backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items", null);
                 backpacksDataConfig.save(backpacksFile);
             } catch (IOException ex){
                 ex.printStackTrace();
@@ -991,12 +993,12 @@ public class BackpacksUtil {
 
             updateCachedBackpack();
 
-            backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items.Size", backpackSize);
+            backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items.Size", backpackSize);
 
             for (ItemStack item : inv.getContents()){
                 if (item != null){
 
-                    backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items." + slot + ".ITEMSTACK", item);
+                    backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items." + slot + ".ITEMSTACK", item);
 
                     slot++;
                 }
@@ -1037,7 +1039,7 @@ public class BackpacksUtil {
             int slot = 0;
 
             try {
-                backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id, null);
+                backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id, null);
                 backpacksDataConfig.save(backpacksFile);
             } catch (IOException ex){
                 ex.printStackTrace();
@@ -1046,14 +1048,14 @@ public class BackpacksUtil {
 
             updateCachedBackpack();
 
-            backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".Size", backpackSize);
+            backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id + ".Size", backpackSize);
 
             oldDataVersionUpdater(p, id, false, true, true);
 
             for (ItemStack item : inv.getContents()){
                 if (item != null){
 
-                    backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id + "." + slot + ".ITEMSTACK", item);
+                    backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id + "." + slot + ".ITEMSTACK", item);
 
                     slot++;
                 }
@@ -1081,25 +1083,25 @@ public class BackpacksUtil {
 
     private void oldDataVersionUpdater(Player p, boolean needToSetNewDimensions, boolean needToSetNewOwner, boolean needToSetNewOwnerID) {
         if (needToSetNewDimensions){
-            backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items.Size", Integer.parseInt(backpacksConfig.getString("Options.BackPack_Default_Size")));
+            backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items.Size", Integer.parseInt(backpacksConfig.getString("Options.BackPack_Default_Size")));
         }
         if (needToSetNewOwner){
-            backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items.PlayerName", p.getName());
+            backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items.PlayerName", p.getName());
         }
         if (needToSetNewOwnerID){
-            backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items.UniqueID", p.getUniqueId().toString());
+            backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items.UniqueID", p.getUniqueId().toString());
         }
     }
 
     private void oldDataVersionUpdater(Player p, String id, boolean needToSetNewDimensions, boolean needToSetNewOwner, boolean needToSetNewOwnerID) {
         if (needToSetNewDimensions){
-            backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".Size", Integer.parseInt(backpacksConfig.getString("Options.BackPack_Default_Size")));
+            backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id + ".Size", Integer.parseInt(backpacksConfig.getString("Options.BackPack_Default_Size")));
         }
         if (needToSetNewOwner){
-            backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".PlayerName", p.getName());
+            backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id + ".PlayerName", p.getName());
         }
         if (needToSetNewOwnerID){
-            backpacksDataConfig.set("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".UniqueID", p.getUniqueId().toString());
+            backpacksDataConfig.set("Inventories." + p.getUniqueId() + ".Items-" + id + ".UniqueID", p.getUniqueId().toString());
         }
     }
 
@@ -1197,7 +1199,7 @@ public class BackpacksUtil {
         // Items can be -> Items- or just Items in the config, the default and old backpacks will have Items only, newer will be like
         // Items-1 or anyway an ID, I'm just getting the ID with this which's what I need.
         try {
-            for (String key : backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId().toString()).getKeys(false)) {
+            for (String key : backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId()).getKeys(false)) {
                 if (!key.equalsIgnoreCase("Items")) {
                     backpacksIDs.add(key.substring(6));
                 } else {
@@ -1217,7 +1219,7 @@ public class BackpacksUtil {
         // Items can be -> Items- or just Items in the config, the default and old backpacks will have Items only, newer will be like
         // Items-1 or anyway an ID, I'm just getting the ID with this which's what I need.
         try {
-            for (String ignored : backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId().toString()).getKeys(false)) {
+            for (String ignored : backpacksDataConfig.getConfigurationSection("Inventories." + p.getUniqueId()).getKeys(false)) {
                 backpacksNumber++;
             }
         } catch (NullPointerException ignored){}
@@ -1227,10 +1229,10 @@ public class BackpacksUtil {
 
     private boolean checkDimensionError(Player p) {
         try{
-            if (backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items" + ".Size") == null){
+            if (backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items" + ".Size") == null){
                 return true;
             }
-            Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items" + ".Size"));
+            Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items" + ".Size"));
         } catch (NumberFormatException ex){
             return true;
         }
@@ -1239,10 +1241,10 @@ public class BackpacksUtil {
 
     private boolean checkDimensionError(Player p, String id) {
         try{
-            if (backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".Size") == null){
+            if (backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items-" + id + ".Size") == null){
                 return true;
             }
-            Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".Size"));
+            Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items-" + id + ".Size"));
         } catch (NumberFormatException ex){
             return true;
         }
@@ -1250,19 +1252,19 @@ public class BackpacksUtil {
     }
 
     private boolean checkBackpackOwnerMissing(Player p) {
-        return backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items.PlayerName") == null;
+        return backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items.PlayerName") == null;
     }
 
     private boolean checkBackpackOwnerMissing(Player p, String id) {
-        return backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".PlayerName") == null;
+        return backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items-" + id + ".PlayerName") == null;
     }
 
     private boolean checkBackpackOwnerIDMissing(Player p) {
-        return backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items.UniqueID") == null;
+        return backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items.UniqueID") == null;
     }
 
     private boolean checkBackpackOwnerIDMissing(Player p, String id) {
-        return backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".UniqueID") == null;
+        return backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items-" + id + ".UniqueID") == null;
     }
 
     private OfflinePlayer getOfflinePlayer(String name) {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
@@ -26,6 +26,7 @@ import tech.mcprison.prison.spigot.SpigotPrison;
 import tech.mcprison.prison.spigot.SpigotUtil;
 import tech.mcprison.prison.spigot.compat.Compatibility;
 import tech.mcprison.prison.spigot.configs.BackpacksConfig;
+import tech.mcprison.prison.spigot.game.SpigotPlayer;
 
 /**
  * @author GABRYCA
@@ -830,9 +831,10 @@ public class BackpacksUtil {
         }
 
         try {
-            backPackSize = Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items.Size"));
+            backPackSize = Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items.Size"));
         } catch (NumberFormatException ignored){}
-        return backPackSize;
+
+        return getBackpackPermSize(p, backPackSize);
     }
 
     private int getSize(Player p, String id) {
@@ -846,6 +848,24 @@ public class BackpacksUtil {
         try {
             backPackSize = Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId().toString() + ".Items-" + id + ".Size"));
         } catch (NumberFormatException ignored){}
+
+        return getBackpackPermSize(p, backPackSize);
+    }
+
+    private int getBackpackPermSize(Player p, int backPackSize) {
+        SpigotPlayer sPlayer = new SpigotPlayer(p);
+        List<String> perms = sPlayer.getPermissions("prison.backpack.size.");
+        int value = 0;
+        for (String permNumber : perms){
+            int newValue = Integer.parseInt(permNumber.substring(21));
+            if (newValue > value){
+                value = (int) Math.ceil((float)newValue / 9) * 9;
+            }
+        }
+
+        if (value != 0){
+            return value;
+        }
         return backPackSize;
     }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
@@ -612,6 +612,8 @@ public class BackpacksUtil {
      * Backpacksconfig option -> Options.BackPack_Access_And_Item_If_Limit_Is_0 is false by default, so a player can't own
      * a backpack if the limit is 0 and won't get the item to open one, also he won't have access to the /gui backpack command.
      *
+     * @param p - Player.
+     *
      * @return boolean
      * */
     public boolean canOwnBackpack(Player p){

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
@@ -748,7 +748,7 @@ public class BackpacksUtil {
         updateCachedBackpack();
 
         // Must be multiple of 9.
-        if (size % 9 != 0 || size > 54){
+        if ((size % 9 != 0 || size > 54) && size != 0){
             return;
         }
 
@@ -768,7 +768,7 @@ public class BackpacksUtil {
         updateCachedBackpack();
 
         // Must be multiple of 9.
-        if (size % 9 != 0 || size > 54){
+        if ((size % 9 != 0 || size > 54) && size != 0){
             return;
         }
 
@@ -828,13 +828,16 @@ public class BackpacksUtil {
         updateCachedBackpack();
 
         int backPackSize = backpackDefaultSize;
-        if (backPackSize % 9 != 0){
-            backPackSize = (int) Math.ceil((float)backPackSize / 9) * 9;
-        }
 
         try {
             backPackSize = Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items.Size"));
         } catch (NumberFormatException ignored){}
+
+        if (backPackSize % 9 != 0){
+            backPackSize = (int) Math.ceil((float)backPackSize / 9) * 9;
+        }
+
+        if (backPackSize == 0) backPackSize = 9;
 
         return getBackpackPermSize(p, backPackSize);
     }
@@ -843,13 +846,16 @@ public class BackpacksUtil {
         updateCachedBackpack();
 
         int backPackSize = backpackDefaultSize;
-        if (backPackSize % 9 != 0){
-            backPackSize = (int) Math.ceil((float)backPackSize / 9) * 9;
-        }
 
         try {
             backPackSize = Integer.parseInt(backpacksDataConfig.getString("Inventories." + p.getUniqueId() + ".Items-" + id + ".Size"));
         } catch (NumberFormatException ignored){}
+
+        if (backPackSize % 9 != 0){
+            backPackSize = (int) Math.ceil((float)backPackSize / 9) * 9;
+        }
+
+        if (backPackSize == 0) backPackSize = 9;
 
         return getBackpackPermSize(p, backPackSize);
     }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/backpacks/BackpacksUtil.java
@@ -606,6 +606,18 @@ public class BackpacksUtil {
         return backpacksLimitGet(p);
     }
 
+
+    /**
+     * Check if a Player can own a Backpack depending on limit and config options even if the limit is set to 0.
+     * Backpacksconfig option -> Options.BackPack_Access_And_Item_If_Limit_Is_0 is false by default, so a player can't own
+     * a backpack if the limit is 0 and won't get the item to open one, also he won't have access to the /gui backpack command.
+     *
+     * @return boolean
+     * */
+    public boolean canOwnBackpack(Player p){
+        return playerCanOwnBackpack(p);
+    }
+
     /**
      * Java getBoolean's broken so I made my own.
      * */
@@ -760,10 +772,14 @@ public class BackpacksUtil {
     }
 
     private void giveBackpackToPlayerOnJoinItem(Player p) {
-        if (getBoolean(backpacksConfig.getString("Options.BackPack_Item_OnJoin"))) {
-        	String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "backpack item" );
+        if (getBoolean(backpacksConfig.getString("Options.BackPack_Item_OnJoin")) && playerCanOwnBackpack(p)) {
+            String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "backpack item" );
             Bukkit.dispatchCommand(p, registeredCmd);
         }
+    }
+
+    private boolean playerCanOwnBackpack(Player p){
+        return !(!getBoolean(backpacksConfig.getString("Options.BackPack_Access_And_Item_If_Limit_Is_0")) && getBackpacksLimit(p) == 0);
     }
 
     private boolean resetBackpackMethod(Player p) {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotBackpackCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotBackpackCommands.java
@@ -126,7 +126,7 @@ public class PrisonSpigotBackpackCommands extends PrisonSpigotBaseCommands {
         }
 
         // Must be multiple of 9.
-        if (sizeInt % 9 != 0 || sizeInt > 54){
+        if ((sizeInt % 9 != 0 || sizeInt > 54) && sizeInt != 0){
             Output.get().sendWarn(sender, SpigotPrison.format(getMessages().getString("Message.BackPackResizeNotMultiple9")));
             return;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotBackpackCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotBackpackCommands.java
@@ -1,5 +1,6 @@
 package tech.mcprison.prison.spigot.commands;
 
+import at.pcgamingfreaks.Minepacks.Bukkit.API.Backpack;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.entity.Player;
@@ -291,6 +292,11 @@ public class PrisonSpigotBackpackCommands extends PrisonSpigotBaseCommands {
 
         if (getBoolean(BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission_Enabled")) && !p.hasPermission(BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission"))){
             Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.MissingPermission") + " [" + BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission") + "]"));
+            return;
+        }
+
+        if (!BackpacksUtil.get().canOwnBackpack(p)){
+            Output.get().sendInfo(sender, SpigotPrison.format(messages.getString("Message.BackPackCantOwn")));
             return;
         }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotBackpackCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotBackpackCommands.java
@@ -76,7 +76,7 @@ public class PrisonSpigotBackpackCommands extends PrisonSpigotBaseCommands {
 
     @Command(identifier = "backpack delete", description = "Delete a player's backpack.", permissions = "prison.admin", onlyPlayers = false)
     private void deleteBackpackCommand(CommandSender sender,
-    @Arg(name = "Backpack Owner", description = "The backpack owner name", def = "null") String name,
+    @Arg(name = "Owner", description = "The backpack owner name", def = "null") String name,
                                        @Arg(name = "id", description = "The backpack ID optional", def = "null") String id){
 
         if (name.equalsIgnoreCase("null")){
@@ -108,7 +108,7 @@ public class PrisonSpigotBackpackCommands extends PrisonSpigotBaseCommands {
 
     @Command(identifier = "backpack set size", description = "Resize a player's backpack.", permissions = "prison.admin", onlyPlayers = false)
     private void resizeBackpackCommand(CommandSender sender,
-                                       @Arg(name = "Backpack Owner", description = "The backpack owner name", def = "null") String name,
+                                       @Arg(name = "Owner", description = "The backpack owner name", def = "null") String name,
                                        @Arg(name = "Backpack size", description = "Backpack size multiple of 9", def = "9") String size,
                                        @Arg(name = "id", description = "The backpack ID optional", def = "null") String id){
 
@@ -157,6 +157,106 @@ public class PrisonSpigotBackpackCommands extends PrisonSpigotBaseCommands {
         Output.get().sendInfo(sender, SpigotPrison.format(getMessages().getString("Message.BackPackResizeDone")));
     }
 
+    @Command(identifier = "backpack limit", permissions = "prison.admin", description = "Backpacks limit for player, to use this multiple backpacks must be enabled from the backpacks config or it won't have effect.", onlyPlayers = false)
+    private void backpackLimitMainCommand(CommandSender sender){
+        sender.dispatchCommand("backpack limit help");
+    }
+
+    @Command(identifier = "backpack limit set", permissions = "prison.admin", description = "Set backpacks limit of a player, to use this multiple backpacks must be enabled or it won't have effect.", onlyPlayers = false)
+    private void setBackpackLimitCommand(CommandSender sender,
+                                         @Arg(name = "Owner", description = "The backpack owner name", def = "null") String name,
+                                         @Arg(name = "Limit", description = "The Backpacks limit that a player can own", def = "null") String limit) {
+
+        if (name.equalsIgnoreCase("null") || limit.equalsIgnoreCase("null")){
+            Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitMissingParam")));
+            return;
+        }
+
+        int limitInt;
+        try{
+            limitInt = Integer.parseInt(limit);
+        } catch (NumberFormatException ex){
+            Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitNotNumber")));
+            return;
+        }
+
+        if (Bukkit.getPlayerExact(name) != null){
+            BackpacksUtil.get().setBackpacksLimit(Bukkit.getPlayerExact(name), limitInt);
+        } else {
+            BackpacksUtil.get().setBackpacksLimit(BackpacksUtil.get().getBackpackOwnerOffline(name), limitInt);
+        }
+
+        Output.get().sendInfo(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitSuccess")));
+    }
+
+    @Command(identifier = "backpack limit add", permissions = "prison.admin", description = "Increment backpacks limit of a player, to use this multiple backpacks must be enabled or it won't have effect.", onlyPlayers = false)
+    private void addBackpackLimitCommand(CommandSender sender,
+                                         @Arg(name = "Owner", description = "The backpack owner name", def = "null") String name,
+                                         @Arg(name = "Limit", description = "The Backpacks increment value", def = "null") String limit) {
+
+        if (name.equalsIgnoreCase("null") || limit.equalsIgnoreCase("null")){
+            Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitMissingParam")));
+            return;
+        }
+
+        int limitInt;
+        try{
+            limitInt = Integer.parseInt(limit);
+        } catch (NumberFormatException ex){
+            Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitNotNumber")));
+            return;
+        }
+
+        if (Bukkit.getPlayerExact(name) != null){
+            limitInt = BackpacksUtil.get().getBackpacksLimit(Bukkit.getPlayerExact(name)) + limitInt;
+            BackpacksUtil.get().setBackpacksLimit(Bukkit.getPlayerExact(name), limitInt);
+        } else {
+            limitInt = BackpacksUtil.get().getBackpacksLimit(BackpacksUtil.get().getBackpackOwnerOffline(name)) + limitInt;
+            BackpacksUtil.get().setBackpacksLimit(BackpacksUtil.get().getBackpackOwnerOffline(name), limitInt);
+        }
+
+        Output.get().sendInfo(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitSuccess")));
+    }
+
+    @Command(identifier = "backpack limit decrement", permissions = "prison.admin", description = "Decrement backpacks limit of a player, to use this multiple backpacks must be enabled or it won't have effect.", onlyPlayers = false)
+    private void decrementBackpackLimitCommand(CommandSender sender,
+                                         @Arg(name = "Owner", description = "The backpack owner name", def = "null") String name,
+                                         @Arg(name = "Value", description = "The Backpacks decrement value", def = "null") String limit) {
+
+        if (name.equalsIgnoreCase("null") || limit.equalsIgnoreCase("null")){
+            Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitMissingParam")));
+            return;
+        }
+
+        int limitInt;
+        try{
+            limitInt = Integer.parseInt(limit);
+        } catch (NumberFormatException ex){
+            Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitNotNumber")));
+            return;
+        }
+
+        if (Bukkit.getPlayerExact(name) != null){
+            limitInt = BackpacksUtil.get().getBackpacksLimit(Bukkit.getPlayerExact(name)) - limitInt;
+            if (limitInt >= 0) {
+                BackpacksUtil.get().setBackpacksLimit(Bukkit.getPlayerExact(name), limitInt);
+            } else {
+                Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitDecrementFail")));
+                return;
+            }
+        } else {
+            limitInt = BackpacksUtil.get().getBackpacksLimit(BackpacksUtil.get().getBackpackOwnerOffline(name)) - limitInt;
+            if (limitInt >= 0) {
+                BackpacksUtil.get().setBackpacksLimit(BackpacksUtil.get().getBackpackOwnerOffline(name), limitInt);
+            } else {
+                Output.get().sendWarn(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitDecrementFail")));
+                return;
+            }
+        }
+
+        Output.get().sendInfo(sender, SpigotPrison.format(messages.getString("Message.BackPackLimitSuccess")));
+    }
+
     @Command(identifier = "backpack admin", description = "Open backpack admin GUI", permissions = "prison.admin", onlyPlayers = true)
     private void openBackpackAdminGUI(CommandSender sender){
 
@@ -184,7 +284,7 @@ public class PrisonSpigotBackpackCommands extends PrisonSpigotBaseCommands {
 
         if (isDisabledWorld(p)) return;
 
-        if (getBoolean(BackpacksUtil.get().getBackpacksConfig().getString("Options.Multiple-BackPacks-For-Player-Enabled")) && (Integer.parseInt(BackpacksUtil.get().getBackpacksConfig().getString("Options.Multiple-BackPacks-For-Player")) <= BackpacksUtil.get().getNumberOwnedBackpacks(p)) && !BackpacksUtil.get().getBackpacksIDs(p).contains(id)){
+        if (getBoolean(BackpacksUtil.get().getBackpacksConfig().getString("Options.Multiple-BackPacks-For-Player-Enabled")) && (BackpacksUtil.get().reachedBackpacksLimit(p) && !BackpacksUtil.get().getBackpacksIDs(p).contains(id))){
             Output.get().sendInfo(sender, SpigotPrison.format(messages.getString("Message.BackPackOwnLimitReached") + " [" + BackpacksUtil.get().getNumberOwnedBackpacks(p) + "]"));
             return;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
@@ -255,7 +255,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         }
 
         if (!getBoolean(sellAllUtil.sellAllConfig.getString("Options.Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Enabled"))){
-            Output.get().sendError(sender, SpigotPrison.format("Disabled from sellallconfig.yml: Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Enabled = false."));
+            sellAllSellCommand(sender, "");
             return;
         }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
@@ -23,9 +23,9 @@ import tech.mcprison.prison.spigot.sellall.SellAllUtil;
  * @author GABRYCA
  * @author RoyalBlueRanger (rBluer)
  */
-public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
+public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
 
-    private static SellAllPrisonCommands instance;
+    private static PrisonSpigotSellAllCommands instance;
     private SellAllUtil sellAllUtil = SellAllUtil.get();
     private final Configuration messages = SpigotPrison.getInstance().getMessagesConfig();
 
@@ -39,9 +39,9 @@ public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
     /**
      * Get SellAll Commands instance.
      * */
-    public static SellAllPrisonCommands get() {
+    public static PrisonSpigotSellAllCommands get() {
         if (instance == null && isEnabled()) {
-            instance = new SellAllPrisonCommands();
+            instance = new PrisonSpigotSellAllCommands();
         }
         if (instance == null){
             return null;
@@ -194,7 +194,7 @@ public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
             Output.get().sendInfo(sender, SpigotPrison.format(messages.getString("Message.SellAllAutoPerUserToggleableDisabled")));
         }
     }
-    
+
     @Command(identifier = "sellall sell", description = "SellAll sell command", onlyPlayers = true)
 	public void sellAllSellCommand(CommandSender sender,
 			@Arg(name = "notification", def="",
@@ -223,9 +223,46 @@ public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
 
         boolean notifications = !(notification != null && "silent".equalsIgnoreCase( notification ));
         boolean bySignOnly = notification != null && "bySignOnly".equalsIgnoreCase( notification );
-        
+
         sellAllUtil.sellAllSell(p, notifications, bySignOnly);
     }
+
+    @Command(identifier = "sellall delaysell", description = "Like SellAll Sell command but this will be delayed for some " +
+            "seconds and if sellall sell commands are triggered during this delay, " +
+            "they will sum up to the total value that will be visible in a notification at the end of the delay. " +
+            "Running more of these commands before a delay have been completed won't reset it and will do the same of /sellall sell " +
+            "without a notification (silently).", onlyPlayers = true)
+    public void sellAllSellWithDelayCommand(CommandSender sender){
+
+        if (!isEnabled()) return;
+
+        Player p = getSpigotPlayer(sender);
+
+        if (p == null){
+            Output.get().sendInfo(sender, SpigotPrison.format("&cSorry but you can't use that from the console!"));
+            return;
+        }
+
+        if (sellAllUtil.isDisabledWorld(p)) return;
+
+        boolean sellPermissionEnabled = getBoolean(sellAllUtil.getSellAllConfig().getString("Options.Sell_Permission_Enabled"));
+        if (sellPermissionEnabled){
+            String permission = sellAllUtil.getSellAllConfig().getString("Options.Sell_Permission");
+            if (permission == null || !p.hasPermission(permission)){
+                Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.SellAllMissingPermission") + " [" + permission + "]"));
+                return;
+            }
+        }
+
+        if (!getBoolean(sellAllUtil.sellAllConfig.getString("Options.Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Enabled"))){
+            Output.get().sendError(sender, SpigotPrison.format("Disabled from sellallconfig.yml: Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Enabled = false."));
+            return;
+        }
+
+        SellAllUtil.get().addToAutoSellTask(p);
+        sellAllSellCommand(sender, "");
+    }
+
 
     @Command(identifier = "sellall auto toggle", description = "Let the user enable or disable sellall auto", onlyPlayers = true)
     private void sellAllAutoEnableUser(CommandSender sender){
@@ -324,14 +361,14 @@ public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
      * <p>This will add the XMaterial and value to the sellall.
      * This will update even if the sellall has not been enabled.
      * </p>
-     * 
+     *
      * @param blockAdd
      * @param value
      */
     public void sellAllAddCommand(XMaterial blockAdd, Double value){
 
     	String itemID = blockAdd.name();
-    	
+
     	// If the block or item was already configured, then skip this:
         if (sellAllUtil.getSellAllConfig().getConfigurationSection("Items." + itemID) != null){
             return;
@@ -341,7 +378,7 @@ public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
 
         Output.get().logInfo(SpigotPrison.format("&3 ITEM [" + itemID + ", " + value + messages.getString("Message.SellAllAddSuccess")));
     }
-    
+
     @Command(identifier = "sellall delete", description = "SellAll delete command, remove an item from shop.", permissions = "prison.admin", onlyPlayers = false)
     private void sellAllDeleteCommand(CommandSender sender, @Arg(name = "Item_ID", description = "The Item_ID you want to remove.") String itemID){
 
@@ -579,11 +616,11 @@ public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
     private void sellAllSetDefaultCommand(CommandSender sender){
 
         if (!isEnabled()) return;
-        
+
 		// Setup all the prices in sellall:
         SpigotPlatform platform = (SpigotPlatform) Prison.get().getPlatform();
 		for ( SellAllBlockData xMatCost : platform.buildBlockListXMaterial() ) {
-			
+
 			// Add blocks to sellall:
 			sellAllAddCommand( xMatCost.getBlock(), xMatCost.getPrice() );
 		}

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/SellAllPrisonCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/SellAllPrisonCommands.java
@@ -1,4 +1,4 @@
-package tech.mcprison.prison.spigot.sellall;
+package tech.mcprison.prison.spigot.commands;
 
 import org.bukkit.configuration.Configuration;
 import org.bukkit.entity.Player;
@@ -15,8 +15,9 @@ import tech.mcprison.prison.internal.CommandSender;
 import tech.mcprison.prison.output.Output;
 import tech.mcprison.prison.spigot.SpigotPlatform;
 import tech.mcprison.prison.spigot.SpigotPrison;
-import tech.mcprison.prison.spigot.commands.PrisonSpigotBaseCommands;
 import tech.mcprison.prison.spigot.game.SpigotPlayer;
+import tech.mcprison.prison.spigot.sellall.SellAllBlockData;
+import tech.mcprison.prison.spigot.sellall.SellAllUtil;
 
 /**
  * @author GABRYCA

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/BackpacksConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/BackpacksConfig.java
@@ -58,7 +58,7 @@ public class BackpacksConfig extends SpigotConfigComponents{
         conf = YamlConfiguration.loadConfiguration(file);
     }
 
-    public void dataConfig(String key, String value){
+    public void dataConfig(String key, Object value){
         if (conf.getString(key) == null) {
             conf.set(key, value);
             changeCount++;
@@ -66,21 +66,21 @@ public class BackpacksConfig extends SpigotConfigComponents{
     }
 
     private void values(){
-        dataConfig("Options.BackPack_Use_Permission_Enabled", "false");
+        dataConfig("Options.BackPack_Use_Permission_Enabled", false);
         dataConfig("Options.BackPack_Use_Permission", "prison.backpack");
         dataConfig("Options.BackPack_Default_Size", "54");
-        dataConfig("Options.BackPack_AutoPickup_Usable", "false");
-        dataConfig("Options.Back_Pack_GUI_Opener_Item", "true");
+        dataConfig("Options.BackPack_AutoPickup_Usable", false);
+        dataConfig("Options.Back_Pack_GUI_Opener_Item", true);
         dataConfig("Options.BackPack_Item", "CHEST");
         dataConfig("Options.BackPack_Item_Title", "&3Backpack");
-        dataConfig("Options.BackPack_Item_OnJoin", "true");
-        dataConfig("Options.BackPack_Access_And_Item_If_Limit_Is_0", "false");
-        dataConfig("Options.BackPack_Lose_Items_On_Death", "false");
-        dataConfig("Options.BackPack_Open_Sound_Enabled", "true");
+        dataConfig("Options.BackPack_Item_OnJoin", true);
+        dataConfig("Options.BackPack_Access_And_Item_If_Limit_Is_0", false);
+        dataConfig("Options.BackPack_Lose_Items_On_Death", false);
+        dataConfig("Options.BackPack_Open_Sound_Enabled", true);
         dataConfig("Options.BackPack_Open_Sound", "BLOCK_CHEST_OPEN");
-        dataConfig("Options.BackPack_Close_Sound_Enabled", "true");
+        dataConfig("Options.BackPack_Close_Sound_Enabled", true);
         dataConfig("Options.BackPack_Close_Sound", "BLOCK_CHEST_CLOSE");
-        dataConfig("Options.Multiple-BackPacks-For-Player-Enabled", "false");
+        dataConfig("Options.Multiple-BackPacks-For-Player-Enabled", false);
         dataConfig("Options.Multiple-BackPacks-For-Player", "2");
     }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/BackpacksConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/BackpacksConfig.java
@@ -74,6 +74,7 @@ public class BackpacksConfig extends SpigotConfigComponents{
         dataConfig("Options.BackPack_Item", "CHEST");
         dataConfig("Options.BackPack_Item_Title", "&3Backpack");
         dataConfig("Options.BackPack_Item_OnJoin", "true");
+        dataConfig("Options.BackPack_Access_And_Item_If_Limit_Is_0", "false");
         dataConfig("Options.BackPack_Lose_Items_On_Death", "false");
         dataConfig("Options.BackPack_Open_Sound_Enabled", "true");
         dataConfig("Options.BackPack_Open_Sound", "BLOCK_CHEST_OPEN");

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/GuiConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/GuiConfig.java
@@ -65,7 +65,7 @@ public class GuiConfig extends SpigotConfigComponents{
         conf = YamlConfiguration.loadConfiguration(file);
     }
 
-    private void dataConfig(String key, String value){
+    private void dataConfig(String key, Object value){
     	if (conf.getString(key) == null) {
     		conf.set(key, value);
     		changeCount++;
@@ -74,23 +74,23 @@ public class GuiConfig extends SpigotConfigComponents{
 
     // All the strings of the config should be here
     private void values(){
-        dataConfig("Options.Ranks.GUI_Enabled","true");
-        dataConfig("Options.Ranks.Permission_GUI_Enabled","false");
+        dataConfig("Options.Ranks.GUI_Enabled", true);
+        dataConfig("Options.Ranks.Permission_GUI_Enabled", false);
         dataConfig("Options.Ranks.Permission_GUI","prison.gui.ranks");
         dataConfig("Options.Ranks.Item_gotten_rank","TRIPWIRE_HOOK");
         dataConfig("Options.Ranks.Item_not_gotten_rank","REDSTONE_BLOCK");
-        dataConfig("Options.Ranks.Enchantment_effect_current_rank","true");
+        dataConfig("Options.Ranks.Enchantment_effect_current_rank", true);
         dataConfig("Options.Ranks.Ladder","default");
-        dataConfig("Options.Ranks.Number_of_Rank_Player_GUI", "false");
-        dataConfig("Options.Mines.GUI_Enabled","true");
-        dataConfig("Options.Mines.Permission_GUI_Enabled","false");
+        dataConfig("Options.Ranks.Number_of_Rank_Player_GUI",  false);
+        dataConfig("Options.Mines.GUI_Enabled", true);
+        dataConfig("Options.Mines.Permission_GUI_Enabled", false);
         dataConfig("Options.Mines.Permission_GUI","prison.gui.mines");
         dataConfig("Options.Mines.PermissionWarpPlugin","mines.tp.");
         dataConfig("Options.Mines.CommandWarpPlugin","mines tp");
-        dataConfig("Options.Prestiges.GUI_Enabled","true");
-        dataConfig("Options.Prestiges.Permission_GUI_Enabled","false");
+        dataConfig("Options.Prestiges.GUI_Enabled", true);
+        dataConfig("Options.Prestiges.Permission_GUI_Enabled", false);
         dataConfig("Options.Prestiges.Permission_GUI","prison.gui.prestiges");
-        dataConfig("Options.Setup.EnabledGUI", "true");
+        dataConfig("Options.Setup.EnabledGUI", true);
         dataConfig("Options.Titles.PlayerRanksGUI", "&3Player -> Ranks");
         dataConfig("Options.Titles.PlayerPrestigesGUI", "&3Player -> Prestiges");
         dataConfig("Options.Titles.PlayerMinesGUI", "&3Player -> Mines");

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
@@ -50,10 +50,14 @@ public class MessagesConfig extends SpigotConfigComponents{
     }
 
     private void dataConfig(String key, String value){
+        if (conf.get(key) == null) {
+            conf.set(key, value);
+            changeCount++;
+        }
+    }
 
-        String originalString = conf.getString(key);
-
-        if (originalString == null) {
+    private void dataConfig(String key, boolean value){
+        if (conf.get(key) == null) {
             conf.set(key, value);
             changeCount++;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
@@ -202,6 +202,10 @@ public class MessagesConfig extends SpigotConfigComponents{
         dataConfig("Message.BackPackResizeNotInt", "Backpack's size value isn't a number.");
         dataConfig("Message.BackPackResizeNotMultiple9", "Backpack's size must be a multiple of 9 and max 54.");
         dataConfig("Message.BackPackResizeDone", "If the Backpack wasn't missing, it got resized with success!");
+        dataConfig("Message.BackPackLimitMissingParam", "You're missing some arguments required to set the backpacks limit!");
+        dataConfig("Message.BackPackLimitNotNumber", "The Backpacks Limit number isn't a number!");
+        dataConfig("Message.BackPackLimitSuccess", "The Backpacks Limit got edited with success!");
+        dataConfig("Message.BackPackLimitDecrementFail", "The Backpacks limit decremented of that value would be negative, operation canceled!");
         dataConfig("Message.CantGetRanksAdmin", "Can't get Ranks, there might be &cno ranks&7 or the Ranks module's &cdisabled&7.");
         dataConfig("Message.CantRunGUIFromConsole", "You cannot run the GUI from the console.");
         dataConfig("Message.CantGiveItemFromConsole", "You can't get an item as the console.");

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
@@ -252,6 +252,8 @@ public class MessagesConfig extends SpigotConfigComponents{
         dataConfig("Message.rankTagRenameClosed", "Rename tag &cclosed&7, nothing got changed!");
         dataConfig("Message.rankGuiDisabledOrAllGuiDisabled", "GUI and/or GUI Ranks is &cdisabled&7. Check GuiConfig.yml (%s %s)");
         dataConfig("Message.rankGuiMissingPermission", "You lack the &cpermissions&7 to use the Ranks GUI.");
+        dataConfig("Message.SellAllAutoSellEarnedMoney", "You earned with AutoSell: ");
+        dataConfig("Message.SellAllAutoSellEarnedMoneyCurrency", "$");
         dataConfig("Message.SellAllAutoSellMissingPermission", "You don't have the &cpermission&7 to edit AutoSell.");
         dataConfig("Message.SellAllAutoSellEnabled", "Autosell has been &aenabled&7.");
         dataConfig("Message.SellAllAutoSellDisabled", "Autosell has been &cdisabled&7.");

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
@@ -206,6 +206,7 @@ public class MessagesConfig extends SpigotConfigComponents{
         dataConfig("Message.BackPackLimitNotNumber", "The Backpacks Limit number isn't a number!");
         dataConfig("Message.BackPackLimitSuccess", "The Backpacks Limit got edited with success!");
         dataConfig("Message.BackPackLimitDecrementFail", "The Backpacks limit decremented of that value would be negative, operation canceled!");
+        dataConfig("Message.BackPackListEmpty", "There aren't backpacks in this server.");
         dataConfig("Message.CantGetRanksAdmin", "Can't get Ranks, there might be &cno ranks&7 or the Ranks module's &cdisabled&7.");
         dataConfig("Message.CantRunGUIFromConsole", "You cannot run the GUI from the console.");
         dataConfig("Message.CantGiveItemFromConsole", "You can't get an item as the console.");

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/MessagesConfig.java
@@ -207,6 +207,7 @@ public class MessagesConfig extends SpigotConfigComponents{
         dataConfig("Message.BackPackLimitSuccess", "The Backpacks Limit got edited with success!");
         dataConfig("Message.BackPackLimitDecrementFail", "The Backpacks limit decremented of that value would be negative, operation canceled!");
         dataConfig("Message.BackPackListEmpty", "There aren't backpacks in this server.");
+        dataConfig("Message.BackPackCantOwn", "Sorry but looks like you can't own Backpacks!");
         dataConfig("Message.CantGetRanksAdmin", "Can't get Ranks, there might be &cno ranks&7 or the Ranks module's &cdisabled&7.");
         dataConfig("Message.CantRunGUIFromConsole", "You cannot run the GUI from the console.");
         dataConfig("Message.CantGiveItemFromConsole", "You can't get an item as the console.");

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/SellAllConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/SellAllConfig.java
@@ -99,6 +99,8 @@ public class SellAllConfig extends SpigotConfigComponents {
         dataConfig("Options.Full_Inv_AutoSell_perUserToggleable", "false");
         dataConfig("Options.Full_Inv_AutoSell_perUserToggleable_Need_Perm", "false");
         dataConfig("Options.Full_Inv_AutoSell_PerUserToggleable_Permission", "prison.sellall.toggle");
+        dataConfig("Options.Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Enabled", "true");
+        dataConfig("Options.Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Delay_Seconds", "10");
         dataConfig("Options.Multiplier_Enabled", "false");
         dataConfig("Options.Multiplier_Default", "1");
         dataConfig("Options.Multiplier_Permission_Only_Higher", "false");

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/SellAllConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/SellAllConfig.java
@@ -60,7 +60,7 @@ public class SellAllConfig extends SpigotConfigComponents {
         conf = YamlConfiguration.loadConfiguration(file);
     }
 
-    public void dataConfig(String key, String value){
+    public void dataConfig(String key, Object value){
         if (conf.getString(key) == null) {
             conf.set(key, value);
             changeCount++;
@@ -68,44 +68,44 @@ public class SellAllConfig extends SpigotConfigComponents {
     }
 
     private void values(){
-        dataConfig("Options.GUI_Enabled", "true");
-        dataConfig("Options.GUI_Permission_Enabled", "true");
+        dataConfig("Options.GUI_Enabled", true);
+        dataConfig("Options.GUI_Permission_Enabled", true);
         dataConfig("Options.GUI_Permission","prison.admin");
-        dataConfig("Options.Sell_Permission_Enabled","false");
+        dataConfig("Options.Sell_Permission_Enabled", false);
         dataConfig("Options.Sell_Permission","prison.sell");
-        dataConfig("Options.Sell_Per_Block_Permission_Enabled", "false");
+        dataConfig("Options.Sell_Per_Block_Permission_Enabled", false);
         dataConfig("Options.Sell_Per_Block_Permission", "prison.sellall.");
-        dataConfig("Options.Sell_Delay_Enabled", "false");
+        dataConfig("Options.Sell_Delay_Enabled", false);
         dataConfig("Options.Sell_Delay_Seconds", "5");
-        dataConfig("Options.Sell_Notify_Enabled", "true");
-        dataConfig("Options.Sell_Sound_Enabled", "true");
+        dataConfig("Options.Sell_Notify_Enabled", true);
+        dataConfig("Options.Sell_Sound_Enabled", true);
         dataConfig("Options.Sell_Sound_Success_Name", "ENTITY_PLAYER_LEVELUP");
         dataConfig("Options.Sell_Sound_Fail_Name", "BLOCK_ANVIL_PLACE");
-        dataConfig("Options.Sell_Prison_BackPack_Items", "true");
-        dataConfig("Options.Sell_MinesBackPacks_Plugin_Backpack", "true");
+        dataConfig("Options.Sell_Prison_BackPack_Items", true);
+        dataConfig("Options.Sell_MinesBackPacks_Plugin_Backpack", true);
         dataConfig("Options.SellAll_Currency", "default");
-        dataConfig("Options.SellAll_Sign_Enabled", "false");
-        dataConfig("Options.SellAll_Sign_Use_Permission_Enabled", "false");
+        dataConfig("Options.SellAll_Sign_Enabled", false);
+        dataConfig("Options.SellAll_Sign_Use_Permission_Enabled", false);
         dataConfig("Options.SellAll_Sign_Use_Permission", "prison.sign");
-        dataConfig("Options.SellAll_By_Sign_Only", "false");
+        dataConfig("Options.SellAll_By_Sign_Only", false);
         dataConfig("Options.SellAll_By_Sign_Only_Bypass_Permission", "prison.admin");
-        dataConfig("Options.SellAll_Sign_Notify", "false");
+        dataConfig("Options.SellAll_Sign_Notify", false);
         dataConfig("Options.SellAll_Sign_Visible_Tag", "&7[&3SellAll&7]");
-        dataConfig("Options.Player_GUI_Enabled","true");
-        dataConfig("Options.Player_GUI_Permission_Enabled","false");
+        dataConfig("Options.Player_GUI_Enabled", true);
+        dataConfig("Options.Player_GUI_Permission_Enabled",false);
         dataConfig("Options.Player_GUI_Permission","prison.sellall.playergui");
-        dataConfig("Options.Full_Inv_AutoSell", "false");
-        dataConfig("Options.Full_Inv_AutoSell_Notification", "true");
-        dataConfig("Options.Full_Inv_AutoSell_perUserToggleable", "false");
-        dataConfig("Options.Full_Inv_AutoSell_perUserToggleable_Need_Perm", "false");
+        dataConfig("Options.Full_Inv_AutoSell", false);
+        dataConfig("Options.Full_Inv_AutoSell_Notification", true);
+        dataConfig("Options.Full_Inv_AutoSell_perUserToggleable", false);
+        dataConfig("Options.Full_Inv_AutoSell_perUserToggleable_Need_Perm", false);
         dataConfig("Options.Full_Inv_AutoSell_PerUserToggleable_Permission", "prison.sellall.toggle");
-        dataConfig("Options.Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Enabled", "true");
+        dataConfig("Options.Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Enabled", true);
         dataConfig("Options.Full_Inv_AutoSell_EarnedMoneyNotificationDelay_Delay_Seconds", "10");
-        dataConfig("Options.Multiplier_Enabled", "false");
+        dataConfig("Options.Multiplier_Enabled", false);
         dataConfig("Options.Multiplier_Default", "1");
-        dataConfig("Options.Multiplier_Permission_Only_Higher", "false");
-        dataConfig("Options.ShiftAndRightClickSellAll.Enabled", "false");
-        dataConfig("Options.ShiftAndRightClickSellAll.PermissionEnabled", "false");
+        dataConfig("Options.Multiplier_Permission_Only_Higher", false);
+        dataConfig("Options.ShiftAndRightClickSellAll.Enabled", false);
+        dataConfig("Options.ShiftAndRightClickSellAll.PermissionEnabled", false);
         dataConfig("Options.ShiftAndRightClickSellAll.Permission", "prison.player");
     }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/SpigotConfigComponents.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/SpigotConfigComponents.java
@@ -1,5 +1,7 @@
 package tech.mcprison.prison.spigot.configs;
 
+import org.bukkit.configuration.Configuration;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -17,5 +19,4 @@ public abstract class SpigotConfigComponents {
             }
         }
     }
-
 }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
@@ -32,7 +32,6 @@ import tech.mcprison.prison.PrisonAPI;
 import tech.mcprison.prison.integration.PermissionIntegration;
 import tech.mcprison.prison.internal.CommandSender;
 import tech.mcprison.prison.internal.Player;
-import tech.mcprison.prison.spigot.sellall.SellAllPrisonCommands;
 import tech.mcprison.prison.spigot.sellall.SellAllUtil;
 import tech.mcprison.prison.util.Text;
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
@@ -1559,7 +1559,7 @@ public class ListenersPrisonManager implements Listener {
 
     private void prisonManagerGUI(InventoryClickEvent e, Player p, String buttonNameMain) {
 
-        // Check the Item display name and do open the right GUI
+        // Check the Item display name and do open the right GUI.
         switch (buttonNameMain) {
             case "Ranks - Ladders": {
                 SpigotLaddersGUI gui = new SpigotLaddersGUI(p, 0);
@@ -1567,21 +1567,27 @@ public class ListenersPrisonManager implements Listener {
                 break;
             }
 
-            // Check the Item display name and do open the right GUI
+            // Check the Item display name and do open the right GUI.
             case "AutoManager": {
-                SpigotAutoFeaturesGUI gui = new SpigotAutoFeaturesGUI(p);
-                gui.open();
+
+                // Check if the autofeatures config isn't null.
+                if(SpigotGUIComponents.afConfig() != null) {
+                    SpigotAutoFeaturesGUI gui = new SpigotAutoFeaturesGUI(p);
+                    gui.open();
+                } else {
+                    Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("Can't find an autofeatures config, maybe they're disabled."));
+                }
                 break;
             }
 
-            // Check the Item display name and do open the right GUI
+            // Check the Item display name and do open the right GUI.
             case "Mines": {
                 SpigotMinesGUI gui = new SpigotMinesGUI(p, 0);
                 gui.open();
                 break;
             }
 
-            // Check the Item display name and do open the right GUI
+            // Check the Item display name and do open the right GUI.
             case "SellAll": {
                 SellAllAdminGUI gui = new SellAllAdminGUI(p);
                 gui.open();
@@ -1594,13 +1600,13 @@ public class ListenersPrisonManager implements Listener {
             }
         }
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
     private void laddersGUI(InventoryClickEvent e, Player p, String buttonNameMain, Module module, String[] parts) {
 
-        // Check if the Ranks module's loaded
+        // Check if the Ranks module's loaded.
         if(!(module instanceof PrisonRanks)){
             Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("The GUI can't open because the &3Rank module &cisn't loaded"));
             p.closeInventory();
@@ -1617,11 +1623,11 @@ public class ListenersPrisonManager implements Listener {
             return;
         }
 
-        // Get the ladder by the name of the button got before
+        // Get the ladder by the name of the button got before.
         ladder = Optional.of(PrisonRanks.getInstance().getLadderManager().getLadder(buttonNameMain));
 
         // When the player click an item with shift and right click, e.isShiftClick should be enough but i want
-        // to be sure's a right click
+        // to be sure's a right click.
         if (e.isShiftClick() && e.isRightClick()) {
 
             // Execute the command
@@ -1634,11 +1640,11 @@ public class ListenersPrisonManager implements Listener {
 
         }
 
-        // Open the GUI of ranks
+        // Open the GUI of ranks.
         SpigotRanksGUI gui = new SpigotRanksGUI(p, ladder, 0);
         gui.open();
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
@@ -1653,19 +1659,19 @@ public class ListenersPrisonManager implements Listener {
             return;
         }
 
-        // Get the rank
+        // Get the rank.
         Rank rank = PrisonRanks.getInstance().getRankManager().getRank(buttonNameMain);
 
-        // Check if the rank exist
+        // Check if the rank exist.
         if (rank == null) {
             Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThe rank " + buttonNameMain + " does not exist."));
             return;
         }
 
-        // Check clicks
+        // Check clicks.
         if (e.isShiftClick() && e.isRightClick()) {
 
-            // Execute the command
+            // Execute the command.
             Bukkit.dispatchCommand(p, "ranks delete " + buttonNameMain);
             e.setCancelled(true);
             p.closeInventory();
@@ -1675,234 +1681,234 @@ public class ListenersPrisonManager implements Listener {
 
         } else {
 
-            // Open a GUI
+            // Open a GUI.
             SpigotRankManagerGUI gui = new SpigotRankManagerGUI(p, rank);
             gui.open();
 
         }
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
     private void playerPrestigesGUI(InventoryClickEvent e, Player p, String buttonNameMain) {
 
-        // Check the button name and do the actions
+        // Check the button name and do the actions.
         if (buttonNameMain.equalsIgnoreCase("Prestige")){
-            // Close the inventory
+            // Close the inventory.
             p.closeInventory();
-            // Execute the command
+            // Execute the command.
             Bukkit.dispatchCommand(p, "prestige");
         }
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
     private void prestigeConfirmationGUI(InventoryClickEvent e, Player p, String buttonNameMain) {
 
-        // Check the button name and do the actions
+        // Check the button name and do the actions.
         if (buttonNameMain.equalsIgnoreCase("Confirm: Prestige")){
-            // Execute the command
+            // Execute the command.
             Bukkit.dispatchCommand(p, "rankup prestiges");
-            // Close the inventory
+            // Close the inventory.
             p.closeInventory();
         } else if (buttonNameMain.equalsIgnoreCase("Cancel: Don't Prestige")){
-            // Send a message to the player
+            // Send a message to the player.
             Output.get().sendInfo(new SpigotPlayer(p), SpigotPrison.format("&cCancelled"));
-            // Close the inventory
+            // Close the inventory.
             p.closeInventory();
         }
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
     private void rankManagerGUI(InventoryClickEvent e, Player p, String[] parts) {
 
-        // Output finally the buttonName and the minename explicit out of the array
+        // Output finally the buttonName and the minename explicit out of the array.
         String buttonName = parts[0];
         String rankName = parts[1];
 
-        // Get the rank
+        // Get the rank.
         Rank rank = PrisonRanks.getInstance().getRankManager().getRank(rankName);
 
-        // Check the button name and do the actions
+        // Check the button name and do the actions.
         if (buttonName.equalsIgnoreCase("RankupCommands")){
 
-            // Check if the rank exist
+            // Check if the rank exist.
             if (rank == null) {
-                // Send a message to the player
+                // Send a message to the player.
                 Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThe rank " + rankName + " does not exist."));
                 return;
             }
 
-            // Check the rankupCommand of the Rank
+            // Check the rankupCommand of the Rank.
             if (rank.getRankUpCommands() == null) {
-                // Send a message to the player
+                // Send a message to the player.
                 Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere aren't commands for this rank anymore."));
             }
 
-            // Open the GUI of commands
+            // Open the GUI of commands.
             else {
                 SpigotRankUPCommandsGUI gui = new SpigotRankUPCommandsGUI(p, rank);
                 gui.open();
             }
 
-        // Check the button name and do the actions
+        // Check the button name and do the actions.
         } else if (buttonName.equalsIgnoreCase("RankPrice")){
 
-            // Check and open a GUI
+            // Check and open a GUI.
             if(rank != null) {
                 SpigotRankPriceGUI gui = new SpigotRankPriceGUI(p, (int) rank.getCost(), rank.getName());
                 gui.open();
             }
 
-        // Check the button name and do the actions
+        // Check the button name and do the actions.
         } else if (buttonName.equalsIgnoreCase("RankTag")){
 
-            // Send messages to the player
+            // Send messages to the player.
             Output.get().sendInfo(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.rankTagRename")));
             Output.get().sendInfo(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.rankTagRenameClose")));
-            // Start the async task
+            // Start the async task.
             tempChatVariable = rankName;
             chatInteractData(p, ChatMode.RankName);
             p.closeInventory();
         }
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
     private void playerRanksGUI(InventoryClickEvent e, Player p, String buttonNameMain) {
 
-        // Check the buttonName and do the actions
+        // Check the buttonName and do the actions.
         if (buttonNameMain.equals(SpigotPrison.format(messages.getString("Lore.Rankup").substring(2)))){
             Bukkit.dispatchCommand(p, "rankup " + guiConfig.getString("Options.Ranks.Ladder"));
             p.closeInventory();
         }
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
     private void rankUPCommandsGUI(InventoryClickEvent e, Player p, String buttonNameMain) {
 
-        // Check the clickType
+        // Check the clickType.
         if (e.isShiftClick() && e.isRightClick()) {
 
-            // Execute the command
+            // Execute the command.
             Bukkit.dispatchCommand(p, "ranks command remove " + buttonNameMain);
-            // Cancel the event
+            // Cancel the event.
             e.setCancelled(true);
-            // Close the inventory
+            // Close the inventory.
             p.closeInventory();
             return;
 
         }
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
     private void rankPriceGUI(InventoryClickEvent e, Player p, String[] parts) {
 
-        // Rename the parts
+        // Rename the parts.
         String part1 = parts[0];
         String part2 = parts[1];
         String part3 = parts[2];
 
-        // Initialize the variable
+        // Initialize the variable.
         int decreaseOrIncreaseValue = 0;
 
-        // If there're enough parts init another variable
+        // If there're enough parts init another variable.
         if (parts.length == 4){
             decreaseOrIncreaseValue = Integer.parseInt(parts[3]);
         }
 
-        // Check the button name and do the actions
+        // Check the button name and do the actions.
         if (part1.equalsIgnoreCase("Confirm:")) {
 
-            // Check the click type and do the actions
+            // Check the click type and do the actions.
             if (e.isLeftClick()){
 
-                // Execute the command
+                // Execute the command.
                 Bukkit.dispatchCommand(p,"ranks set cost " + part2 + " " + part3);
 
-                // Close the inventory
+                // Close the inventory.
                 p.closeInventory();
 
                 return;
 
-                // Check the click type and do the actions
+                // Check the click type and do the actions.
             } else if (e.isRightClick()){
 
-                // Send a message to the player
+                // Send a message to the player.
                 Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cEvent cancelled."));
 
                 e.setCancelled(true);
 
-                // Close the inventory
+                // Close the inventory.
                 p.closeInventory();
 
                 return;
             } else {
 
-                // Cancel the event
+                // Cancel the event.
                 e.setCancelled(true);
                 return;
             }
         }
 
-        // Give to val a value
+        // Give to val a value.
         int val = Integer.parseInt(part2);
 
-        // Check the calculator symbol
+        // Check the calculator symbol.
         if (part3.equals("-")){
 
-            // Check if the value's already too low
+            // Check if the value's already too low.
             if (!((val -  decreaseOrIncreaseValue) < 0)) {
 
-                // If it isn't too low then decrease it
+                // If it isn't too low then decrease it.
                 val = val - decreaseOrIncreaseValue;
 
-                // If it is too low
+                // If it is too low.
             } else {
 
-                // Tell to the player that the value's too low
+                // Tell to the player that the value's too low.
                 Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cToo low value."));
 
                 e.setCancelled(true);
 
-                // Close the inventory
+                // Close the inventory.
                 p.closeInventory();
                 return;
             }
 
-            // Open an updated GUI after the value changed
+            // Open an updated GUI after the value changed.
             SpigotRankPriceGUI gui = new SpigotRankPriceGUI(p, val, part1);
             gui.open();
 
             // Check the calculator symbol
         } else if (part3.equals("+")){
 
-            // Check if the value isn't too high
+            // Check if the value isn't too high.
             if (!((val + decreaseOrIncreaseValue) > 2147483646)) {
 
                 // Increase the value
                 val = val + decreaseOrIncreaseValue;
 
-                // If the value's too high then do the action
+                // If the value's too high then do the action.
             } else {
 
-                // Close the GUI and tell it to the player
+                // Close the GUI and tell it to the player.
                 Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cToo high value."));
                 e.setCancelled(true);
                 p.closeInventory();
                 return;
             }
 
-            // Open a new updated GUI with new values
+            // Open a new updated GUI with new values.
             SpigotRankPriceGUI gui = new SpigotRankPriceGUI(p, val, part1);
             gui.open();
 
@@ -1920,29 +1926,29 @@ public class ListenersPrisonManager implements Listener {
             return;
         }
 
-        // Variables
+        // Variables.
         PrisonMines pMines = PrisonMines.getInstance();
         Mine m = pMines.getMine(buttonNameMain);
 
-        // Check the clicks
+        // Check the clicks.
         if (e.isShiftClick() && e.isRightClick()) {
-            // Execute the command
+            // Execute the command.
             Bukkit.dispatchCommand(p, "mines delete " + buttonNameMain);
-            // Cancel the event
+            // Cancel the event.
             e.setCancelled(true);
-            // Close the inventory
+            // Close the inventory.
             p.closeInventory();
-            // Open a GUI
+            // Open a GUI.
             SpigotMinesConfirmGUI gui = new SpigotMinesConfirmGUI(p, buttonNameMain);
             gui.open();
             return;
         }
 
-        // Open the GUI of mines info
+        // Open the GUI of mines info.
         SpigotMineInfoGUI gui = new SpigotMineInfoGUI(p, m, buttonNameMain);
         gui.open();
 
-        // Cancel the event
+        // Cancel the event.
         e.setCancelled(true);
     }
 
@@ -1965,79 +1971,79 @@ public class ListenersPrisonManager implements Listener {
 
     private void mineInfoGUI(InventoryClickEvent e, Player p, String[] parts) {
 
-        // Output finally the buttonName and the mineName explicit out of the array
+        // Output finally the buttonName and the mineName explicit out of the array.
         String buttonName = parts[0];
         String mineName = parts[1];
 
-        // Check the name of the button and do the actions
+        // Check the name of the button and do the actions.
         switch (buttonName) {
             case "Blocks_of_the_Mine:":
 
-                // Open the GUI
+                // Open the GUI.
                 SpigotMinesBlocksGUI gui = new SpigotMinesBlocksGUI(p, mineName);
                 gui.open();
 
                 break;
 
-            // Check the name of the button and do the actions
+            // Check the name of the button and do the actions.
             case "Reset_Mine:":
 
-                // Check the clickType and do the actions
+                // Check the clickType and do the actions.
                 if (e.isLeftClick()) {
-                    // Execute the command
+                    // Execute the command.
                     Bukkit.dispatchCommand(p, "mines reset " + mineName);
                 } else if (e.isRightClick()){
-                    // Execute the command
+                    // Execute the command.
                     Bukkit.dispatchCommand(p, "mines set skipReset " + mineName);
                 } else if (e.isRightClick() && e.isShiftClick()){
-                    // Execute the command
+                    // Execute the command.
                     Bukkit.dispatchCommand(p, "mines set zeroBlockResetDelay " + mineName);
                 }
 
-                // Cancel the event
+                // Cancel the event.
                 e.setCancelled(true);
 
                 break;
 
-            // Check the name of the button and do the actions
+            // Check the name of the button and do the actions.
             case "Mine_Spawn:":
 
-                // Execute the command
+                // Execute the command.
                 Bukkit.dispatchCommand(p, "mines set spawn " + mineName);
 
-                // Cancel the event
+                // Cancel the event.
                 e.setCancelled(true);
                 break;
 
-            // Check the name of the button and do the actions
+            // Check the name of the button and do the actions.
             case "Mine_notifications:":
 
-                // Open the GUI
+                // Open the GUI.
                 SpigotMineNotificationsGUI gui1 = new SpigotMineNotificationsGUI(p, mineName);
                 gui1.open();
 
                 break;
 
-            // Check the name of the button and do the actions
+            // Check the name of the button and do the actions.
             case "TP_to_the_Mine:":
 
-                // Close the inventory
+                // Close the inventory.
                 p.closeInventory();
 
-                // Execute the Command
+                // Execute the Command.
                 Bukkit.dispatchCommand(p, "mines tp " + mineName);
 
                 break;
 
-            // Check the name of the button and do the actions
+            // Check the name of the button and do the actions.
             case "Reset_Time:":
 
-                // Initialize the variables
+                // Initialize the variables.
                 PrisonMines pMines = PrisonMines.getInstance();
                 Mine m = pMines.getMine(mineName);
                 int val = m.getResetTime();
 
-                // Open the GUI
+                // Open the GUI.
                 SpigotMineResetTimeGUI gui2 = new SpigotMineResetTimeGUI(p, val, mineName);
                 gui2.open();
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
@@ -1,6 +1,12 @@
 package tech.mcprison.prison.spigot.gui;
 
-import com.cryptomorin.xseries.XMaterial;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Sign;
@@ -17,6 +23,9 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+
+import com.cryptomorin.xseries.XMaterial;
+
 import tech.mcprison.prison.Prison;
 import tech.mcprison.prison.autofeatures.AutoFeaturesFileConfig;
 import tech.mcprison.prison.autofeatures.AutoFeaturesFileConfig.AutoFeatures;
@@ -30,24 +39,37 @@ import tech.mcprison.prison.ranks.data.RankLadder;
 import tech.mcprison.prison.spigot.SpigotPrison;
 import tech.mcprison.prison.spigot.SpigotUtil;
 import tech.mcprison.prison.spigot.backpacks.BackpacksUtil;
-import tech.mcprison.prison.spigot.gui.backpacks.BackpacksAdminGUI;
-import tech.mcprison.prison.spigot.gui.backpacks.BackpacksAdminListGUI;
-import tech.mcprison.prison.spigot.gui.backpacks.BackpacksAdminPlayerListGUI;
-import tech.mcprison.prison.spigot.sellall.SellAllPrisonCommands;
 import tech.mcprison.prison.spigot.compat.Compatibility;
 import tech.mcprison.prison.spigot.game.SpigotPlayer;
 import tech.mcprison.prison.spigot.gui.autofeatures.SpigotAutoBlockGUI;
 import tech.mcprison.prison.spigot.gui.autofeatures.SpigotAutoFeaturesGUI;
 import tech.mcprison.prison.spigot.gui.autofeatures.SpigotAutoPickupGUI;
 import tech.mcprison.prison.spigot.gui.autofeatures.SpigotAutoSmeltGUI;
-import tech.mcprison.prison.spigot.gui.mine.*;
-import tech.mcprison.prison.spigot.gui.rank.*;
-import tech.mcprison.prison.spigot.gui.sellall.*;
-import tech.mcprison.prison.spigot.sellall.SellAllUtil;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
+import tech.mcprison.prison.spigot.gui.backpacks.BackpacksAdminGUI;
+import tech.mcprison.prison.spigot.gui.backpacks.BackpacksAdminListGUI;
+import tech.mcprison.prison.spigot.gui.backpacks.BackpacksAdminPlayerListGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotBlocksListGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotBlocksMineListGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotMineBlockPercentageGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotMineInfoGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotMineNotificationRadiusGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotMineNotificationsGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotMineResetTimeGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotMinesBlocksGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotMinesConfirmGUI;
+import tech.mcprison.prison.spigot.gui.mine.SpigotMinesGUI;
+import tech.mcprison.prison.spigot.gui.rank.SpigotLaddersGUI;
+import tech.mcprison.prison.spigot.gui.rank.SpigotRankManagerGUI;
+import tech.mcprison.prison.spigot.gui.rank.SpigotRankPriceGUI;
+import tech.mcprison.prison.spigot.gui.rank.SpigotRankUPCommandsGUI;
+import tech.mcprison.prison.spigot.gui.rank.SpigotRanksGUI;
+import tech.mcprison.prison.spigot.gui.sellall.SellAllAdminAutoSellGUI;
+import tech.mcprison.prison.spigot.gui.sellall.SellAllAdminBlocksGUI;
+import tech.mcprison.prison.spigot.gui.sellall.SellAllAdminGUI;
+import tech.mcprison.prison.spigot.gui.sellall.SellAllDelayGUI;
+import tech.mcprison.prison.spigot.gui.sellall.SellAllPrestigesMultiplierGUI;
+import tech.mcprison.prison.spigot.gui.sellall.SellAllPrestigesSetMultiplierGUI;
+import tech.mcprison.prison.spigot.gui.sellall.SellAllPriceGUI;
 
 /**
  * @author GABRYCA
@@ -238,11 +260,13 @@ public class ListenersPrisonManager implements Listener {
                                     return;
                                 }
 
+                                boolean bySignOnly = false;
                                 if (sellAllConfig.getString("Options.SellAll_By_Sign_Only").equalsIgnoreCase("true")) {
-                                    SellAllUtil sellAll = SellAllUtil.get();
-                                    if (sellAll != null) {
-                                        sellAll.toggleSellAllSign();
-                                    }
+                                	bySignOnly = true;
+//                                    SellAllUtil sellAll = SellAllUtil.get();
+//                                    if (sellAll != null) {
+//                                        sellAll.toggleSellAllSign();
+//                                    }
                                 }
 
                                 if (sellAllConfig.getString("Options.SellAll_Sign_Notify").equalsIgnoreCase("true")) {
@@ -251,7 +275,7 @@ public class ListenersPrisonManager implements Listener {
 
                                 // Execute the sellall command
                                 String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( "sellall sell" );
-                                Bukkit.dispatchCommand(p, registeredCmd);
+                                Bukkit.dispatchCommand(p, registeredCmd + ( bySignOnly ? " bySignOnly" : ""));
                             }
                         } catch (IndexOutOfBoundsException ignored) {}
                     }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
@@ -414,7 +414,7 @@ public class ListenersPrisonManager implements Listener {
                 module = Prison.get().getModuleManager().getModule(PrisonRanks.MODULE_NAME).orElse(null);
                 title = compat.getGUITitle(e).substring(2);
             } catch (ArrayIndexOutOfBoundsException ex){
-                Output.get().sendError(new SpigotPlayer(p), "An error occurred while using the GUI, please check logs.");
+                Output.get().sendWarn(new SpigotPlayer(p), "An error occurred while using the GUI, please check logs.");
                 ex.printStackTrace();
                 return;
             }
@@ -805,7 +805,7 @@ public class ListenersPrisonManager implements Listener {
                 conf.set("Options.Mines.MaterialType." + parts[1], parts[0]);
                 conf.save(sellAllFile);
             } catch (IOException ex){
-                Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.SellAllConfigSaveFail")));
+                Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.SellAllConfigSaveFail")));
                 ex.printStackTrace();
                 return;
             }
@@ -1575,7 +1575,7 @@ public class ListenersPrisonManager implements Listener {
                     SpigotAutoFeaturesGUI gui = new SpigotAutoFeaturesGUI(p);
                     gui.open();
                 } else {
-                    Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("Can't find an autofeatures config, maybe they're disabled."));
+                    Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("Can't find an autofeatures config, maybe they're disabled."));
                 }
                 break;
             }
@@ -1608,7 +1608,7 @@ public class ListenersPrisonManager implements Listener {
 
         // Check if the Ranks module's loaded.
         if(!(module instanceof PrisonRanks)){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("The GUI can't open because the &3Rank module &cisn't loaded"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("The GUI can't open because the &3Rank module &cisn't loaded"));
             p.closeInventory();
             e.setCancelled(true);
             return;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
@@ -135,7 +135,7 @@ public class ListenersPrisonManager implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onSignEditing(SignChangeEvent e){
 
         sellAllConfig = SpigotPrison.getInstance().getSellAllConfig();
@@ -170,7 +170,7 @@ public class ListenersPrisonManager implements Listener {
         } catch (IndexOutOfBoundsException ignored){}
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerInteractEvent(PlayerInteractEvent e){
 
         sellAllConfig = SpigotPrison.getInstance().getSellAllConfig();
@@ -180,10 +180,8 @@ public class ListenersPrisonManager implements Listener {
             boolean sellAllTriggerEnabled = getBoolean(sellAllConfig.getString("Options.ShiftAndRightClickSellAll.Enabled"));
             if (sellAllTriggerEnabled) {
                 // Check if the action if Shift + Right Click.
-                if (e.getAction().equals(Action.RIGHT_CLICK_AIR) && e.getPlayer().isSneaking()) {
-
-                    // Get player.
-                    Player p = e.getPlayer();
+                Player p = e.getPlayer();
+                if (e.getAction().equals(Action.RIGHT_CLICK_AIR) && p.isSneaking()) {
 
                     // Check if a permission's required.
                     boolean permissionSellAllTriggerEnabled = getBoolean(sellAllConfig.getString("Options.ShiftAndRightClickSellAll.PermissionEnabled"));
@@ -260,14 +258,11 @@ public class ListenersPrisonManager implements Listener {
                                     return;
                                 }
 
-                                boolean bySignOnly = false;
-                                if (sellAllConfig.getString("Options.SellAll_By_Sign_Only").equalsIgnoreCase("true")) {
-                                	bySignOnly = true;
-//                                    SellAllUtil sellAll = SellAllUtil.get();
-//                                    if (sellAll != null) {
-//                                        sellAll.toggleSellAllSign();
-//                                    }
-                                }
+                                boolean bySignOnly = sellAllConfig.getString("Options.SellAll_By_Sign_Only").equalsIgnoreCase("true");
+                                //                                    SellAllUtil sellAll = SellAllUtil.get();
+                                //                                    if (sellAll != null) {
+                                //                                        sellAll.toggleSellAllSign();
+                                //                                    }
 
                                 if (sellAllConfig.getString("Options.SellAll_Sign_Notify").equalsIgnoreCase("true")) {
                                     Output.get().sendInfo(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.SellAllSignNotify")));
@@ -291,7 +286,7 @@ public class ListenersPrisonManager implements Listener {
         chatEventPlayer.remove(p.getName());
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR,ignoreCancelled = true)
     public void onGuiClosing(InventoryCloseEvent e){
 
         // If the GUI's disabled then return
@@ -382,7 +377,7 @@ public class ListenersPrisonManager implements Listener {
     }
 
     // InventoryClickEvent.
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onClick(InventoryClickEvent e){
 
         // Check if GUIs are enabled.

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/PrisonSetupGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/PrisonSetupGUI.java
@@ -38,7 +38,7 @@ public class PrisonSetupGUI extends SpigotGUIComponents{
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/SpigotPrisonGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/SpigotPrisonGUI.java
@@ -38,7 +38,7 @@ public class SpigotPrisonGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/autofeatures/SpigotAutoBlockGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/autofeatures/SpigotAutoBlockGUI.java
@@ -42,7 +42,7 @@ public class SpigotAutoBlockGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/autofeatures/SpigotAutoFeaturesGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/autofeatures/SpigotAutoFeaturesGUI.java
@@ -41,7 +41,7 @@ public class SpigotAutoFeaturesGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/autofeatures/SpigotAutoPickupGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/autofeatures/SpigotAutoPickupGUI.java
@@ -43,7 +43,7 @@ public class SpigotAutoPickupGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/autofeatures/SpigotAutoSmeltGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/autofeatures/SpigotAutoSmeltGUI.java
@@ -42,7 +42,7 @@ public class SpigotAutoSmeltGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksAdminListGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksAdminListGUI.java
@@ -42,30 +42,34 @@ public class BackpacksAdminListGUI extends SpigotGUIComponents {
             for (String inventoryID : items) {
 
                 String name;
-                name = backpacksData.getString("Inventories." + uuid + "." + inventoryID + ".PlayerName");
+                name = backpacksData.getString("Inventories." + uuid + ".PlayerName");
                 if (name != null && name.equalsIgnoreCase(playerBackpackName)){
 
                     if (backpacksFound < 54) {
-                        String id;
-                        if (!inventoryID.equalsIgnoreCase("items")) {
+                        String id = null;
+                        if (!inventoryID.equalsIgnoreCase("items") && !inventoryID.equalsIgnoreCase("PlayerName") && !inventoryID.equalsIgnoreCase("UniqueID") && !inventoryID.equalsIgnoreCase("Limit")) {
                             id = inventoryID.substring(6);
                         } else {
-                            id = "default";
+                            if (!inventoryID.equalsIgnoreCase("PlayerName") && !inventoryID.equalsIgnoreCase("UniqueID") && !inventoryID.equalsIgnoreCase("Limit")){
+                                id = "default";
+                            }
                         }
-                        List<String> backpacksLore = createLore(
-                                loreShiftAndRightClickToDelete,
-                                "&8----------------",
-                                " ",
-                                loreInfo,
-                                lorePlayerOwner + name,
-                                loreBackpackID + id,
-                                " ",
-                                "&8----------------"
-                        );
+                        if (id != null) {
+                            List<String> backpacksLore = createLore(
+                                    loreShiftAndRightClickToDelete,
+                                    "&8----------------",
+                                    " ",
+                                    loreInfo,
+                                    lorePlayerOwner + name,
+                                    loreBackpackID + id,
+                                    " ",
+                                    "&8----------------"
+                            );
 
-                        ItemStack backpackButton = createButton(XMaterial.CHEST.parseItem(), backpacksLore, "&3" + "Backpack " + name + " " + id);
-                        inv.setItem(backpacksFound, backpackButton);
-                        backpacksFound++;
+                            ItemStack backpackButton = createButton(XMaterial.CHEST.parseItem(), backpacksLore, "&3" + "Backpack " + name + " " + id);
+                            inv.setItem(backpacksFound, backpackButton);
+                            backpacksFound++;
+                        }
                     } else {
                         openGUI(p, inv);
                         return;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksAdminPlayerListGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksAdminPlayerListGUI.java
@@ -6,8 +6,10 @@ import org.bukkit.configuration.Configuration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import tech.mcprison.prison.output.Output;
 import tech.mcprison.prison.spigot.SpigotPrison;
 import tech.mcprison.prison.spigot.backpacks.BackpacksUtil;
+import tech.mcprison.prison.spigot.game.SpigotPlayer;
 import tech.mcprison.prison.spigot.gui.SpigotGUIComponents;
 
 import java.util.List;
@@ -28,7 +30,19 @@ public class BackpacksAdminPlayerListGUI extends SpigotGUIComponents {
         int dimension = 54;
         Inventory inv = Bukkit.createInventory(null, dimension, SpigotPrison.format("&3" + "Backpacks-Admin-Players"));
 
-        Set<String> playerUUID = backpacksData.getConfigurationSection("Inventories").getKeys(false);
+
+        if (backpacksData.getConfigurationSection("Inventories") == null){
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.BackPackListEmpty")));
+            return;
+        }
+
+        Set<String> playerUUID;
+        try {
+            playerUUID = backpacksData.getConfigurationSection("Inventories").getKeys(false);
+        } catch (NullPointerException ex){
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.BackPackListEmpty")));
+            return;
+        }
 
         List<String> backpackLore = createLore(
                 clickToOpen

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksAdminPlayerListGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksAdminPlayerListGUI.java
@@ -38,12 +38,9 @@ public class BackpacksAdminPlayerListGUI extends SpigotGUIComponents {
         for (String uuid : playerUUID) {
 
             String name = null;
-            Set<String> items = backpacksData.getConfigurationSection("Inventories." + uuid).getKeys(false);
-            for (String inventoryID : items) {
-                if (playersFound <= 54) {
-                    if (uuid.equalsIgnoreCase(backpacksData.getString("Inventories." + uuid + "." + inventoryID + ".UniqueID"))) {
-                        name = backpacksData.getString("Inventories." + uuid + "." + inventoryID + ".PlayerName");
-                    }
+            if (playersFound <= 54) {
+                if (uuid.equalsIgnoreCase(backpacksData.getString("Inventories." + uuid + ".UniqueID"))) {
+                    name = backpacksData.getString("Inventories." + uuid + ".PlayerName");
                 }
             }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksListPlayerGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksListPlayerGUI.java
@@ -5,8 +5,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import tech.mcprison.prison.output.Output;
 import tech.mcprison.prison.spigot.SpigotPrison;
 import tech.mcprison.prison.spigot.backpacks.BackpacksUtil;
+import tech.mcprison.prison.spigot.game.SpigotPlayer;
 import tech.mcprison.prison.spigot.gui.SpigotGUIComponents;
 
 import java.util.List;
@@ -20,6 +22,11 @@ public class BackpacksListPlayerGUI extends SpigotGUIComponents {
     }
 
     public void open(){
+
+        if (BackpacksUtil.get().getBackpacksLimit(p) == 0){
+            Output.get().sendInfo(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.BackPackCantOwn")));
+            return;
+        }
 
         int dimension = 54;
         Inventory inv = Bukkit.createInventory(null, dimension, SpigotPrison.format("&3" + p.getName() + " -> Backpacks"));
@@ -60,7 +67,7 @@ public class BackpacksListPlayerGUI extends SpigotGUIComponents {
             }
         }
 
-        if ((BackpacksUtil.get().getBackpacksIDs(p).isEmpty() || !BackpacksUtil.get().reachedBackpacksLimit(p)) && BackpacksUtil.get().getBackpacksLimit(p) != 0) {
+        if (BackpacksUtil.get().getBackpacksIDs(p).isEmpty() || !BackpacksUtil.get().reachedBackpacksLimit(p)) {
             inv.setItem(49, createButton(XMaterial.EMERALD_BLOCK.parseItem(), loreAddBackpackButton, SpigotPrison.format("&aNew Backpack")));
         }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksListPlayerGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/backpacks/BackpacksListPlayerGUI.java
@@ -60,7 +60,7 @@ public class BackpacksListPlayerGUI extends SpigotGUIComponents {
             }
         }
 
-        if (BackpacksUtil.get().getBackpacksIDs(p).isEmpty() || !BackpacksUtil.get().reachedBackpacksLimit(p)) {
+        if ((BackpacksUtil.get().getBackpacksIDs(p).isEmpty() || !BackpacksUtil.get().reachedBackpacksLimit(p)) && BackpacksUtil.get().getBackpacksLimit(p) != 0) {
             inv.setItem(49, createButton(XMaterial.EMERALD_BLOCK.parseItem(), loreAddBackpackButton, SpigotPrison.format("&aNew Backpack")));
         }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineBlockPercentageGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineBlockPercentageGUI.java
@@ -52,7 +52,7 @@ public class SpigotMineBlockPercentageGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineInfoGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineInfoGUI.java
@@ -46,7 +46,7 @@ public class SpigotMineInfoGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineNotificationRadiusGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineNotificationRadiusGUI.java
@@ -46,7 +46,7 @@ public class SpigotMineNotificationRadiusGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineNotificationsGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineNotificationsGUI.java
@@ -50,7 +50,7 @@ public class SpigotMineNotificationsGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv, enabledOrDisabled);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p),SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p),SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineResetTimeGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMineResetTimeGUI.java
@@ -44,7 +44,7 @@ public class SpigotMineResetTimeGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMinesBlocksGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMinesBlocksGUI.java
@@ -105,7 +105,7 @@ public class SpigotMinesBlocksGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv, block, blockmaterial, blockmaterialdisplay);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }
@@ -116,7 +116,7 @@ public class SpigotMinesBlocksGUI extends SpigotGUIComponents {
     	try {
     		buttonsSetup(inv, block, blockmaterial, blockmaterialdisplay);
     	} catch (NullPointerException ex){
-    		Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+    		Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
     		ex.printStackTrace();
     		return true;
     	}

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMinesBlocksGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMinesBlocksGUI.java
@@ -48,7 +48,7 @@ public class SpigotMinesBlocksGUI extends SpigotGUIComponents {
         // Get the dimensions and if needed increases them
         int dimension = 54;
         
-		boolean useNewBlockModel = Prison.get().getPlatform().getConfigBooleanFalse( "use-new-prison-block-model" );
+		boolean useNewBlockModel = Prison.get().getPlatform().isUseNewPrisonBlockModel();
 
         // Create the inventory
         Inventory inv = Bukkit.createInventory(null, dimension, SpigotPrison.format("&3MineInfo -> Blocks"));

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMinesConfirmGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMinesConfirmGUI.java
@@ -41,7 +41,7 @@ public class SpigotMinesConfirmGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMinesGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotMinesGUI.java
@@ -68,7 +68,7 @@ public class SpigotMinesGUI extends SpigotGUIComponents {
         String loreBlocks = messages.getString("Lore.Blocks");
 
         // Global boolean.
-        boolean useNewBlockModel = Prison.get().getPlatform().getConfigBooleanFalse( "use-new-prison-block-model" );
+        boolean useNewBlockModel = Prison.get().getPlatform().isUseNewPrisonBlockModel();
 
         // Only loop over the blocks that we need to show:
         int i = counter;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotPlayerMinesGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/mine/SpigotPlayerMinesGUI.java
@@ -49,14 +49,14 @@ public class SpigotPlayerMinesGUI extends SpigotGUIComponents {
 
         // If the inventory is empty
         if (dimension == 0){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.NoMines")));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.NoMines")));
             p.closeInventory();
             return;
         }
 
         // If the dimension's too big, don't open the GUI
         if (dimension > 54){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.TooManyMines")));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.TooManyMines")));
             p.closeInventory();
             return;
         }
@@ -78,7 +78,7 @@ public class SpigotPlayerMinesGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv, m);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p),"&cThere's a null value in the GuiConfig.yml [broken]");
+            Output.get().sendWarn(new SpigotPlayer(p),"&cThere's a null value in the GuiConfig.yml [broken]");
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotConfirmPrestigeGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotConfirmPrestigeGUI.java
@@ -39,7 +39,7 @@ public class SpigotConfirmPrestigeGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotLaddersGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotLaddersGUI.java
@@ -42,7 +42,7 @@ public class SpigotLaddersGUI extends SpigotGUIComponents {
 
         // If the inventory is empty
         if (lm.getLadders().size() == 0){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.NoLadders")));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.NoLadders")));
             p.closeInventory();
             return;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotPlayerPrestigesGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotPlayerPrestigesGUI.java
@@ -50,7 +50,7 @@ public class SpigotPlayerPrestigesGUI extends SpigotGUIComponents {
         rankPlugin = (PrisonRanks) module;
 
         if (rankPlugin == null){
-            Output.get().sendError(new SpigotPlayer(player), SpigotPrison.format("&3Looks like the Ranks module's disabled"));
+            Output.get().sendWarn(new SpigotPlayer(player), SpigotPrison.format("&3Looks like the Ranks module's disabled"));
             return;
         }
 
@@ -132,7 +132,7 @@ public class SpigotPlayerPrestigesGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(ladder, dimension, inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(getPlayer()), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(getPlayer()), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotPlayerRanksGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotPlayerRanksGUI.java
@@ -65,7 +65,7 @@ public class SpigotPlayerRanksGUI extends SpigotGUIComponents {
         }
 
  	    if (rankPlugin.getPlayerManager() == null) {
- 	        Output.get().sendError(new SpigotPlayer(player), SpigotPrison.format("&c: rankPlugin.getPlayerManager() == null."));
+ 	        Output.get().sendWarn(new SpigotPlayer(player), SpigotPrison.format("&c: rankPlugin.getPlayerManager() == null."));
  	    	return;
  	    }
 
@@ -141,7 +141,7 @@ public class SpigotPlayerRanksGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(dimension, inv, rank, playerRank);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(getPlayer()), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(getPlayer()), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotRankManagerGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotRankManagerGUI.java
@@ -50,7 +50,7 @@ public class SpigotRankManagerGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotRankPriceGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotRankPriceGUI.java
@@ -49,7 +49,7 @@ public class SpigotRankPriceGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotRankUPCommandsGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/rank/SpigotRankUPCommandsGUI.java
@@ -81,7 +81,7 @@ public class SpigotRankUPCommandsGUI extends SpigotGUIComponents {
         try {
             buttonsSetup(inv, command);
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllAdminAutoSellGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllAdminAutoSellGUI.java
@@ -83,7 +83,7 @@ public class SellAllAdminAutoSellGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllAdminBlocksGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllAdminBlocksGUI.java
@@ -113,7 +113,7 @@ public class SellAllAdminBlocksGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllAdminGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllAdminGUI.java
@@ -44,7 +44,7 @@ public class SellAllAdminGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllDelayGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllDelayGUI.java
@@ -43,7 +43,7 @@ public class SellAllDelayGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllPlayerGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllPlayerGUI.java
@@ -84,7 +84,7 @@ public class SellAllPlayerGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllPrestigesMultiplierGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllPrestigesMultiplierGUI.java
@@ -42,7 +42,7 @@ public class SellAllPrestigesMultiplierGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllPrestigesSetMultiplierGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllPrestigesSetMultiplierGUI.java
@@ -44,7 +44,7 @@ public class SellAllPrestigesSetMultiplierGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllPriceGUI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/sellall/SellAllPriceGUI.java
@@ -44,7 +44,7 @@ public class SellAllPriceGUI extends SpigotGUIComponents {
         try {
             buttonsSetup();
         } catch (NullPointerException ex){
-            Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
+            Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format("&cThere's a null value in the GuiConfig.yml [broken]"));
             ex.printStackTrace();
             return true;
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllPrisonCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllPrisonCommands.java
@@ -195,7 +195,10 @@ public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
     }
     
     @Command(identifier = "sellall sell", description = "SellAll sell command", onlyPlayers = true)
-	public void sellAllSellCommand(CommandSender sender){
+	public void sellAllSellCommand(CommandSender sender,
+			@Arg(name = "notification", def="",
+    		description = "Notification about the sellall transaction. Defaults to normal. " +
+    				"'silent' suppresses results. [silent]") String notification ){
 
         if (!isEnabled()) return;
 
@@ -217,7 +220,10 @@ public class SellAllPrisonCommands extends PrisonSpigotBaseCommands {
             }
         }
 
-        sellAllUtil.sellAllSell(p);
+        boolean notifications = !(notification != null && "silent".equalsIgnoreCase( notification ));
+        boolean bySignOnly = notification != null && "bySignOnly".equalsIgnoreCase( notification );
+        
+        sellAllUtil.sellAllSell(p, notifications, bySignOnly);
     }
 
     @Command(identifier = "sellall auto toggle", description = "Let the user enable or disable sellall auto", onlyPlayers = true)

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllUtil.java
@@ -1110,6 +1110,15 @@ public class SellAllUtil {
             // Get money to give + multiplier.
             double moneyToGive = getMoneyWithMultiplier(p, true);
 
+            // Check if Ranks are enabled.
+            ModuleManager modMan = Prison.get().getModuleManager();
+            Module module = modMan == null ? null : modMan.getModule( PrisonRanks.MODULE_NAME ).orElse( null );
+            PrisonRanks rankPlugin = (PrisonRanks) module;
+            if (rankPlugin == null){
+                Output.get().sendError(new SpigotPlayer(p), SpigotPrison.format("Ranks are disabled, you can't use this without Ranks enabled!"));
+                return;
+            }
+
             RankPlayer rankPlayer = PrisonRanks.getInstance().getPlayerManager().getPlayer(sPlayer.getUUID(), sPlayer.getName());
             String currency = sellAllConfig.getString("Options.SellAll_Currency");
             if (currency != null && currency.equalsIgnoreCase("default")) currency = null;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllUtil.java
@@ -53,7 +53,7 @@ public class SellAllUtil {
     private File sellAllFile = new File(SpigotPrison.getInstance().getDataFolder() + "/SellAllConfig.yml");
     public Configuration sellAllConfig = SpigotPrison.getInstance().getSellAllConfig();
     public static List<String> activePlayerDelay = new ArrayList<>();
-    public boolean signUsed = false;
+//    public boolean signUsed = false;
     private final Compatibility compat = SpigotPrison.getInstance().getCompatibility();
     private final ItemStack lapisLazuli = compat.getLapisItemStack();
     private String idBeingProcessedBackpack = null;
@@ -81,13 +81,13 @@ public class SellAllUtil {
         return sellAllConfig;
     }
 
-    /**
-     * Use this to toggle the SellAllSign, essentially this will tell to the SellAll Sell command that you're using a sign
-     * for SellAll.
-     */
-    public void toggleSellAllSign() {
-        sellAllSignToggler();
-    }
+//    /**
+//     * Use this to toggle the SellAllSign, essentially this will tell to the SellAll Sell command that you're using a sign
+//     * for SellAll.
+//     */
+//    public void toggleSellAllSign() {
+//        sellAllSignToggler();
+//    }
 
     /**
      * Get the money to give to the Player depending on the multiplier.
@@ -196,6 +196,10 @@ public class SellAllUtil {
      */
     public void sellAllSell(Player p) {
         sellAllSellPlayer(p);
+    }
+    
+    public void sellAllSell(Player p, boolean notifications, boolean bySignOnly) {
+    	sellAllSellPlayer(p, notifications, bySignOnly);
     }
 
     /**
@@ -1060,22 +1064,25 @@ public class SellAllUtil {
     }
 
     private void sellAllSellPlayer(Player p) {
+    	sellAllSellPlayer( p, true, false );
+    }
+    private void sellAllSellPlayer(Player p, boolean notifications, boolean bySignOnly) {
 
         updateSellAllConfig();
 
         boolean sellAllSignEnabled = getBoolean(sellAllConfig.getString("Options.SellAll_Sign_Enabled"));
         boolean sellAllBySignOnlyEnabled = getBoolean(sellAllConfig.getString("Options.SellAll_By_Sign_Only"));
         String byPassPermission = sellAllConfig.getString("Options.SellAll_By_Sign_Bypass_Permission");
-        if (sellAllSignEnabled && sellAllBySignOnlyEnabled && (byPassPermission != null && !p.hasPermission(byPassPermission))) {
-            if (!signUsed) {
+        if (sellAllSignEnabled && sellAllBySignOnlyEnabled && (byPassPermission == null || byPassPermission != null && !p.hasPermission(byPassPermission))) {
+            if (!bySignOnly) {
                 Output.get().sendWarn(new SpigotPlayer(p), SpigotPrison.format(messages.getString("Message.SellAllSignOnly")));
                 return;
             }
         }
 
-        if (signUsed) signUsed = false;
+//        if (signUsed) signUsed = false;
 
-        boolean sellSoundEnabled = getBoolean(sellAllConfig.getString("Options.Sell_Sound_Enabled"));
+        boolean sellSoundEnabled = notifications && getBoolean(sellAllConfig.getString("Options.Sell_Sound_Enabled"));
         Compatibility compat = SpigotPrison.getInstance().getCompatibility();
         if (!(sellAllConfig.getConfigurationSection("Items.") == null)) {
 
@@ -1093,7 +1100,7 @@ public class SellAllUtil {
 
             rankPlayer.addBalance(currency, moneyToGive);
 
-            boolean sellNotifyEnabled = getBoolean(sellAllConfig.getString("Options.Sell_Notify_Enabled"));
+            boolean sellNotifyEnabled = notifications && getBoolean(sellAllConfig.getString("Options.Sell_Notify_Enabled"));
             if (moneyToGive < 0.001) {
                 if (sellSoundEnabled) {
                     Sound sound;
@@ -1611,11 +1618,11 @@ public class SellAllUtil {
         activePlayerDelay.remove(p.getName());
     }
 
-    private void sellAllSignToggler() {
-        if (!signUsed) {
-            signUsed = true;
-        }
-    }
+//    private void sellAllSignToggler() {
+//        if (!signUsed) {
+//            signUsed = true;
+//        }
+//    }
 
     private double getMoneyFinal(Player player, boolean removeItems) {
         SpigotPlayer sPlayer = new SpigotPlayer(player);

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/spiget/BluesSpigetSemVerComparator.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/spiget/BluesSpigetSemVerComparator.java
@@ -124,14 +124,35 @@ public class BluesSpigetSemVerComparator
 	 */
 	public int compareMCVersionTo( String checkVersion ) {
 		int results = -1;
-		String currentVersion = Bukkit.getVersion().trim().toLowerCase();
-		int i = currentVersion.indexOf("(mc:");
-		int len = currentVersion.length();
-		if ( i >= 0 && (i+4 < len)) {
-			currentVersion = currentVersion.substring( i + 4, len -1 ).trim();
+		String currentVersion = getBukkitVersion();
+		if ( currentVersion != null ) {
 			
 			results = compareTo( currentVersion, checkVersion );
 		}
+		return results;
+	}
+	
+	private String getBukkitVersion() {
+		// Minecraft version: git-Paper-21 (MC: 1.15)
+		
+		return getBukkitVersion( getBukkitVersionRaw() );
+	}
+	private String getBukkitVersionRaw() {
+		return Bukkit.getVersion();
+	}
+	
+	protected String getBukkitVersion( String currentVersion ) {
+		String results = null;
+		
+		if ( currentVersion != null ) {
+			currentVersion = currentVersion.trim().toLowerCase();
+			int i = currentVersion.indexOf("(mc:");
+			int len = currentVersion.length();
+			if ( i >= 0 && (i+4 < len)) {
+				results = currentVersion.substring( i + 4, len - 1 ).trim();
+			}
+		}
+		
 		return results;
 	}
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonUtilsListeners.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonUtilsListeners.java
@@ -23,9 +23,9 @@ public class PrisonUtilsListeners
 		this.unbreakableBlockList = new HashMap<>();
 	}
 	
-	
-    @EventHandler( priority=EventPriority.LOWEST )
-    public void rainbowDecayBlockEvent(PrisonMinesBlockEventEvent e) {
+	// Runtime exception for some reasons here.
+//    @EventHandler( priority=EventPriority.LOWEST )
+//    public void rainbowDecayBlockEvent(PrisonMinesBlockEventEvent e) {
     	
 //    	if ( !e.isCancelled() && e.getParameter() != null &&
 //    			e.getParameter().startsWith("rainbow-decay" ) ) {
@@ -39,7 +39,7 @@ public class PrisonUtilsListeners
 //    		runableTask.submit();
 //    	}
 
-    }
+//    }
 
     /**
      * <p>This event prevents any block that is within the unbreakableBlockList 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonUtilsRepair.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonUtilsRepair.java
@@ -3,6 +3,8 @@ package tech.mcprison.prison.spigot.utils;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.Material;
+
 import tech.mcprison.prison.commands.Arg;
 import tech.mcprison.prison.commands.Command;
 import tech.mcprison.prison.commands.Wildcard;
@@ -297,6 +299,56 @@ public class PrisonUtilsRepair
     		repairItem( item, repaired, repairOptions );
     	}
     }
+    
+    
+	
+	@Command(identifier = "prison utils materialsearch", 
+				description = "Provides a search of bukkit Materials",
+			onlyPlayers = false, permissions = "prison.utils.materialsearch")
+	public void utilMaterialSearch(CommandSender sender, 
+			@Wildcard(join=true)
+			@Arg(name = "search", description = "search words used to match Materials", 
+					def = "") String search ) {
+		
+		if ( search != null && !search.trim().isEmpty() ) {
+			
+			String[] searchTerms = search.trim().toLowerCase().split( " " );
+			
+			StringBuilder sb = new StringBuilder();
+			int count = 0;
+			for ( Material mat : Material.values() ) {
+				String name = mat.name().toLowerCase();
+				
+				if ( wordContains( name, searchTerms ) ) {
+					if ( sb.length() > 0 ) {
+						sb.append( " " );
+					}
+					sb.append( mat.name() );
+					count++;
+				}
+			}
+			
+			if ( sb.length() == 0 ) {
+				sb.append( "<nothing-found>" );
+			}
+			
+			Output.get().logInfo( "MaterialSearch: searchTerms=[%s] results=%s :: %s ",
+					search, Integer.toString( count ), sb.toString() );
+		}
+	}
+	
+	private boolean wordContains( String word, String[] terms ) {
+		boolean found = true;
+		
+		for ( String term : terms ) {
+			if ( !word.contains( term ) ) {
+				found = false;
+				break;
+			}
+		}
+		
+		return found;
+	}
 
 	public boolean isEnableRepairAll() {
 		return enableRepairAll;

--- a/prison-spigot/src/main/resources/config.yml
+++ b/prison-spigot/src/main/resources/config.yml
@@ -143,4 +143,8 @@ prison-mines:
     max-page-elapsed-time-ms: 75
     page-submit-delay-ticks: 1
     page-timeout-check-block-count: 250
+  tp-warmup:
+    enabled: false
+    movementMaxDistance: 1.0
+    delayInTicks: 20
     

--- a/prison-spigot/src/main/resources/config.yml
+++ b/prison-spigot/src/main/resources/config.yml
@@ -121,22 +121,9 @@ default-language: en_US
 
 
 # The storage engine that Prison should use to store data.
-# Ensure that only one is left uncommented out. Also, ensure
-# that you specify your MongoDB or SQL login credentials if necessary.
+# The only valid storageType is json. 
 storageType: "json"
-#storageType: "mongo"
-#storageType: "sql"
 
-# NOTE: The following is not used since SQL and MongoDB are not valid options.
-# Login credentials for either SQL or MongoDB
-#database:
-#  enabled: false
-#  type: sql # sql or mongo
-#  host: localhost
-#  database: prison
-#  username: root
-#  password: root
-#  port: 3306
 
 
 

--- a/prison-spigot/src/main/resources/plugin.yml
+++ b/prison-spigot/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: tech.mcprison.prison.spigot.SpigotPrison
 version: "${version}"
 description: Prison is an all-in-one plugin for the Minecraft prison game mode.
 website: https://prison.jar-mc.com
-softdepend: [Essentials, Vault, ProtocolLib, LuckPerms, WorldEdit, WorldGuard, Multiverse-Core, Multiworld, MVdWPlaceholderAPI, PlaceholderAPI, PermissionsEx, GroupManagerX, GemsEconomy, TokenEnchant, CMI, CMILib, CMIPaperLib, mcMMO, PlotSquared, Multiverse]
+softdepend: [Essentials, Vault, ProtocolLib, LuckPerms, WorldEdit, WorldGuard, Multiverse-Core, Multiworld, MVdWPlaceholderAPI, PlaceholderAPI, PermissionsEx, GroupManagerX, GemsEconomy, TokenEnchant, CMI, CMILib, CMIPaperLib, mcMMO, PlotSquared, Multiverse, FastAsyncWorldEdit]
 
 # Older versions than 1.13 will ignore this, but this will allow 1.13 and up to use newer block types?
 api-version: 1.13

--- a/prison-spigot/src/main/resources/plugin.yml
+++ b/prison-spigot/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: tech.mcprison.prison.spigot.SpigotPrison
 version: "${version}"
 description: Prison is an all-in-one plugin for the Minecraft prison game mode.
 website: https://prison.jar-mc.com
-softdepend: [Essentials, Vault, LuckPerms, Multiverse-Core, Multiworld, MVdWPlaceholderAPI, PlaceholderAPI, GemsEconomy, TokenEnchant, CMI]
+softdepend: [Essentials, Vault, ProtocolLib, LuckPerms, WorldEdit, WorldGuard, Multiverse-Core, Multiworld, MVdWPlaceholderAPI, PlaceholderAPI, PermissionsEx, GroupManagerX, GemsEconomy, TokenEnchant, CMI, CMILib, CMIPaperLib, mcMMO, PlotSquared, Multiverse]
 
 # Older versions than 1.13 will ignore this, but this will allow 1.13 and up to use newer block types?
 api-version: 1.13

--- a/prison-spigot/src/test/java/tech/mcprison/prison/spigot/spiget/BluesSpigetSemVerComparatorTest.java
+++ b/prison-spigot/src/test/java/tech/mcprison/prison/spigot/spiget/BluesSpigetSemVerComparatorTest.java
@@ -1,5 +1,6 @@
 package tech.mcprison.prison.spigot.spiget;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -106,6 +107,16 @@ public class BluesSpigetSemVerComparatorTest
 		// higher than prerelease:
 		assertFalse( bssvc.performComparisons( "1.2.3", 
 										 "1.2.3-alpha.1" ) );
+		
+	}
+	
+	@Test
+	public void test02() {
+		BluesSpigetSemVerComparator bssvc = new BluesSpigetSemVerComparator();
+		
+		String paperTest = "Minecraft version: git-Paper-21 (MC: 1.15)";
+		
+		assertEquals( "1.15", bssvc.getBukkitVersion( paperTest ) );
 		
 	}
 }


### PR DESCRIPTION
v3.2.7 - Prison Update - Fixes a performance issue with v3.2.6

# NOTICE : v3.2.6 had a issue with performance and release v3.2.7 fixes it

* Significant changes to prison for improving support related commands.  The following commands are now recommended to be used to help provide details for troubleshooting.

 *  /prison version all
 *  /mines stats
 *  /mines reset *all*
 *  /mines list
 *  /mines info <mineName> all
 *  /mines stats
 *  
 *  /ranks ladder list
 *  /ranks players all all
 *  /ranks list <ladderName>
 *  /ranks info <rankName> 
 *  /ranks command <rankName>

* If a mine is taking too long to reset, `/mines info` now includes a warning and recommends enabling Mine Reset Paging.

* For all players on the server, force rank changes with one command.
Can use the command as `/ranks set rank *all* *same*` to reset all player's ranks to their current rank.

* Bug Fix: The new Mine Sweeper was added in the last release, but was accidentally always enabled.  This was fixed.


* Significant changes and fixes for backpacks

* Updated a few repos to their more recent releases

* Changes to player teleport to prevent looping and locking a player in place.

* Enhance how the new block model is setup to make for an easier transition to using it.
