### PR TITLE
fix Prison Utils to enable PrisonUtilsPotions only when the Utils mod…

### DIFF
--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonUtilsModule.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonUtilsModule.java
@@ -62,22 +62,18 @@ public class PrisonUtilsModule
 				Prison.get().getCommandHandler().registerCommands( utils );
 				
 			}
-			
-			
-			
+
+			if ( isEnabled( "utils.potions.enabled", true ) ) {
+
+				PrisonUtilsPotions utils = new PrisonUtilsPotions();
+
+				utils.setEnablePotionEffects( isEnabled( "utils.potions.potionEffects.enabled", true ) );
+				// utils.setEnablePotions( isEnabled( "utils.potions.potions.enabled", true ) );
+
+				Prison.get().getCommandHandler().registerCommands( utils );
+
+			}
 		}
-		
-		if ( isEnabled( "utils.potions.enabled", true ) ) {
-			
-			PrisonUtilsPotions utils = new PrisonUtilsPotions();
-			
-			utils.setEnablePotionEffects( isEnabled( "utils.potions.potionEffects.enabled", true ) );
-			// utils.setEnablePotions( isEnabled( "utils.potions.potions.enabled", true ) );
-			
-			Prison.get().getCommandHandler().registerCommands( utils );
-			
-		}
-		
 	}
 
 	@Override


### PR DESCRIPTION
Pull these changes from ValdemarF.

fix Prison Utils to enable PrisonUtilsPotions only when the Utils module is enabled.  It was always being enabled even if Utils was disabled