### PR TITLE
Bleeding branch v3.3.0 alpha.17

### DIFF
--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -18,7 +18,12 @@ These change logs represent the work that has been going on within prison.
 
 
 
-**3.3.0-alpha.16c 2024-03-07** 
+**3.3.0-alpha.16c 2024-03-08** 
+
+
+* **mines block layerStats: rewrote to improve and get rid of the collection manipulations.**
+Found potential problem with air being inserted in to mines.
+Renamed a lot of uses of Location objects to include the name "location" in their variable names instead of "block".
 
 
 * **Mines block layer: Added colors for same IDs so it's easier to read.**  Added a check that sees what block actually exists.  If counts of what should have spawned match whats in the mine for that layer, then it shows only one number.  It shows two numbers if a block's intended spawn does not match what's in the mine.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-02-26
 
 
+* **Mine skip reset: If a mine is reset, send a message to players, but only if the message is defined and not empty: 'skip_reset_message='**
+
+
 
 * **Player sellall Multipliers: Fixed the ranks multiplier to include all ranks that are defined within the sellall multipliers.**
 Added a new function that will gather and list all multipliers that go in to the calculation of the player's total multipliers, which includes the rank multipliers (the sellall multipliers) and also permission based multipliers.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,12 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-02-26
 
 
+
+* **Sellall and GUI message failures: a number of messages that would indicate the player does not have access to that command were changed to remove the permission from the message.**
+This was requested by a couple of admins because they did not want the players to see the internal workings that would otherwise control how the software would behave.
+
+
+
 * **Mine imports: Fix some minor issues to get this to work even better.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,11 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16c 2024-03-15
 
 
+* **Players: Shift the function of getting a player object to the Player classes, such as CommandSender.**
+This is to simplify the code and to put the functionality in one location.
+
+
+
 * **Sellall: New command:  '/sellall items inspect'**
 This new command will inspect what the player is holding, and dump the details so the admin can see exactly how an item/block is created, including lore and enchantments.
 Eventually this information can be used to enhance the ability to sell and buy non-standard items by allowing the admins to filter on lore, enchantments, and/or NBTs.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,10 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16c 2024-04-07
+# 3.3.0-alpha.16c 2024-04-20
+
+
+* **Placeholder bug: The placeholder 'prison_rankup_cost_percent' uses the calculated value of a percentage, but when used with the placeholder attribute, it was found to use the price instead.**  As such, the actual value returned for the placeholder was incorrect.
 
 
 * **Player Manager: Secondary Placeholders:  Setup the secondary placeholder support on the PlayerManager, but it has not been enabled yet** since secondary placeholders on placeholders do not make a lot of sense because each placeholder is only one value and they cannot contain alternative text.  At least not yet.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,10 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16b 2024-02-26
+# 3.3.0-alpha.16b 2024-02-27
+
+
+* **Mine skip reset messaging: Did not have it hooked up in the correct location, so the skip messages were not happening.**
 
 
 * **Mine reset: Under heavy load when performing a mine import, there were seen occasionally errors with concurrent modification errors.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,10 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-03-05
 
 
+* **Mines block layerStats: Added a new command that shows which blocks are in each layer in the mine.**
+There are a lot of future enhancements that can be added to this command, such as checking the actual blocks to see if they are still there, or if there was a problem with the spawning of the blocks.
+
+
 * **Block lists: Added the total chance percentage to be displayed with the blocks.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,10 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16a 2024-02-19
 
 
+* **Bug fix: Prison command handler.  When players are de-op'd, and they do the commands such as `/ranks help` or `/mines help` it was incorrectly showing other sub commands they did not have access to.**
+This now shows the correct sub commands that they have access to.
+
+
 * **Placeholders: topn players - bug fix.  If a player did not have a prestige rank, then it would cause a NPE when using the `prison_top_player_rank_prestiges_nnn_tp` placeholder.**
 Just check to ensure its not null... if it is, then return an empty string.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -16,6 +16,11 @@ These change logs represent the work that has been going on within prison.
 
 # 3.3.0-alpha.16c 2024-03-15
 
+* **SpigotPlayer: Fixed a potential issue if trying to use getRankPlayer() if the ranks module is not enabled.**
+Added a check to ensure it's active.
+We have not seen any reports of issues related to this.
+
+
 
 * **Prison Player: Added a new sendMessage function using Lists of Strings. ** 
 Added a new function getPlatformPlayer() which gets a bukkit player object if the player is online.  This will consolidate a lot of other duplicate code.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,11 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16a 2024-02-19
 
 
+* **Placeholders: Top player rank was using the wrong ladder, which was incorrectly the prestiges rank and not the default rank.**
+Correcting the rank fixed the problem.  This only was an issue if the player did not have a prestige rank.
+
+
+
 * **Mines set resetTime: fix typo in the description where it shows '*all' instead of '*all*'.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -18,7 +18,10 @@ These change logs represent the work that has been going on within prison.
 
 
 
-**3.3.0-alpha.16c 2024-03-10** 
+**3.3.0-alpha.16c 2024-03-11** 
+
+
+* **Prison support listeners: added support for listening to and providing dumps for PlayerDropItemEvent, PlayerPickupItemEvent, and BlockPlaceEvent.**
 
 
 * **Promote & Demote: Improved upon reporting issues with the command.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,12 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16b 2024-02-27
+# 3.3.0-alpha.16b 2024-03-01
+
+
+
+
+* **Mines import: prevent the processing of an importing of a mine if there are problems with the mine's name, or locations.**
 
 
 * **AutoSell: Bug fix: When autosell and sell on inventory is full was all turned off, it would still sell.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16c 2024-04-07
 
 
+* **Player Manager: Secondary Placeholders:  Setup the secondary placeholder support on the PlayerManager, but it has not been enabled yet** since secondary placeholders on placeholders do not make a lot of sense because each placeholder is only one value and they cannot contain alternative text.  At least not yet.
+
+
 * **Localizable: Secondary placeholders:  Rewrote the whole support of secondary placeholders related to players.***
 Expanded the support by making them generic so other data sources can also have their own custom set of placeholders too.  Such as mines.
 This now supports a new interface that will provide the generic support.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16a 2024-02-19
 
 
+* **Mines set resetTime: fix typo in the description where it shows '*all' instead of '*all*'.**
+
+
 * **ranks ladder: applyRanksCostMultiplier command was changed to allow the value of 'true' to be used along with the value of 'apply'.**  This helps to eliminate some confusion on how the command works.
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -4,7 +4,7 @@
 
 ## Change logs
  - **[v3.3.0-alpha - Current](changelog_v3.3.x.md)**
- - [v3.2.0 through v3.3.0-alpha.16](prison_changelogs.md)
+ - [v3.2.0 through v3.3.0-alpha.17](prison_changelogs.md)
  
 * [Known Issues - Open](knownissues_v3.2.x.md)
 * [Known Issues - Resolved](knownissues_v3.2.x_resolved.md)
@@ -18,7 +18,15 @@ These change logs represent the work that has been going on within prison.
 
 
 
-**v3.3.0-alpha.17** 2024-03-20
+
+
+
+
+
+
+# 3.3.0-alpha.17 2024-04-20
+
+**v3.3.0-alpha.17** 2024-04-20
 
 
 
@@ -275,7 +283,7 @@ As a side effect, these two unit test run much faster since it's not trying to s
 
 * **Prison Block change: Add support for display name, which is optional.**
 Setup sellall so it can use the display name now, so renamed items will not be mistaken for vanilla minecraft items.
-More work needs to be done to hoo up displayName to other features, such as sellall and add prison block to mines.
+More work needs to be done to hook up displayName to other features, such as sellall and add prison block to mines.
 
 
 * **Bug fix: Fixed the command `/mines set accessPermission` where it was apply the given perm to all mines.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,10 @@ These change logs represent the work that has been going on within prison.
 
 **3.3.0-alpha.16c 2024-03-11** 
 
+
+* **XSeries: Upgrade from v9.8.0 to v9.9.0**
+
+
 * **Mine bombs: add support for BlockPlacementEvent so if someone is using a Block they can use it as the mine bomb's item.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,10 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16b 2024-02-24** 
 
 
+* **Import Mines: Added the ability to import mines from JetPrisonMines config files.**
+`/mines import jetprisonmines help`
+
+
 * **Prison Command Handler: using config.yml you can now change all of prison's root commands with 'prisonCommandHandler.command-roots'.**
 Can now map 'prison', 'mines', 'ranks', 'gui', 'sellall' to all new command that you want.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,10 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-03-05
 
 
+* **File format: Eliminate the check for file types since there is only one.**
+Currently there isn't a setting to specify what it should be.
+
+
 * **Mines block layerStats: Added a new command that shows which blocks are in each layer in the mine.**
 There are a lot of future enhancements that can be added to this command, such as checking the actual blocks to see if they are still there, or if there was a problem with the spawning of the blocks.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,11 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16c 2024-03-14
+# 3.3.0-alpha.16c 2024-03-15
+
+
+* **Prison ItemStack: remove enchantments from the core ItemStack since prison cannot properly represent it in versions lower than 1.13.x**, plus it was wrong for all spigot versions greater than 1.12.x.
+Added the proper enchantment functions to the SpigotItemStack object.
 
 
 * **Initial setup of sellall lore filtering**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,13 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16b 2024-02-20
+# 3.3.0-alpha.16b 2024-02-26
+
+
+
+* **Player sellall Multipliers: Fixed the ranks multiplier to include all ranks that are defined within the sellall multipliers.**
+Added a new function that will gather and list all multipliers that go in to the calculation of the player's total multipliers, which includes the rank multipliers (the sellall multipliers) and also permission based multipliers.
+This detailed list of the individual multipliers, is viewable for each player that is online with the command `/ranks player <player>` and reveals the actual details of how it's calculated.
 
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,10 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16c 2024-03-10** 
 
 
+* **Promote & Demote: Improved upon reporting issues with the command.**
+There were few situations where the command would exit without reporting why, which was leading to difficulties with using the command effectively. 
+
+
 * **New feature: TopN customization now possible.  The messages and placeholders that you can use are located in the core multi-language files.**
 See the bottom of the files for instructions on usage.
 TopN data is set to delay load so it does not lengthen the startup process.  As such, it now reports that the data is being loaded so it is now clear why there are no entries in the list initially.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,12 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16c 2024-04-20
+# 3.3.0-alpha.17 2024-04-20
+
+
+
+**v3.3.0-alpha.17** 2024-03-20
+
 
 
 * **Mines messages: Secondary placeholders.  Added support for mines' messages to be able to support secondary placeholders within the language files. NOTE: Not usable at this time.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -18,7 +18,12 @@ These change logs represent the work that has been going on within prison.
 
 
 
-**3.3.0-alpha.16c 2024-03-08** 
+**3.3.0-alpha.16c 2024-03-09** 
+
+
+* **Mine resets: Reworked how prison is selecting random blocks per layer, to properly include constraints.**
+The addition of various new features in the past made a mess of the logic, so it's been cleaned up greatly so it now makes sense and should work properly now.
+There is a slight risk, that as blocks are removed from a layer due to reaching it's max constraint value, that future random selections were missing blocks selections and was then inserting AIR. This fixed code now will insert a filler block which has been selected with no constraints, and the largest chance value.
 
 
 * **mines block layerStats: rewrote to improve and get rid of the collection manipulations.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,7 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-03-01
 
 
+* **Sellall and autosell: Refinements were made to the handling of the sellall settings to better stabilize the use of the commands.**  Setting status for the players were moved to the player objects and is now used in all of the related calculations so there is better stability and consistency.
 
 
 * **Mines import: prevent the processing of an importing of a mine if there are problems with the mine's name, or locations.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -18,7 +18,10 @@ These change logs represent the work that has been going on within prison.
 
 
 
-**3.3.0-alpha.16b 2024-02-20** 
+**3.3.0-alpha.16b 2024-02-22** 
+
+* **Bug fix: prison support submit: if the bukkit system cannot extract a file from the jar**, such as plugin.yml, this will prevent the failure of the command.  This will allow the command to continue being processed, but may just skip the extraction.
+
 
 
 * **Placeholders: Top player rank was using the wrong ladder, which was incorrectly the prestiges rank and not the default rank.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,9 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16c 2024-03-07** 
 
 
+* **Mines block layer: Added colors for same IDs so it's easier to read.**  Added a check that sees what block actually exists.  If counts of what should have spawned match whats in the mine for that layer, then it shows only one number.  It shows two numbers if a block's intended spawn does not match what's in the mine.
+
+
 * **Mine reset: added a force to the reset so it will ignore an existing mine reset and allow a new one to begin.***
 When a mine is being reset, there is no way to actually cancel it.  So this allows a large mine to undergo multiple concurrent resets.  Use at your own risk.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,10 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16c 2024-03-15
 
 
+* **Prison API: Added a few new functions to work with ItemStacks.**
+
+
+
 * **Players: Shift the function of getting a player object to the Player classes, such as CommandSender.**
 This is to simplify the code and to put the functionality in one location.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,10 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-03-05
 
 
+* **Bug fix: the check for the time the reset has been going on was incorrect and was fixed.**
+Also all the code for submitting the reset task was moved in to the mutext.  Now, if the reset got hung up, this will properly terminate it and resubmit it.
+
+
 * **File format: Eliminate the check for file types since there is only one.**
 Currently there isn't a setting to specify what it should be.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-02-26
 
 
+* **Mine reset: Under heavy load when performing a mine import, there were seen occasionally errors with concurrent modification errors.**
+Code was changed to minimize that possibility.
+
 
 * **Sellall and GUI message failures: a number of messages that would indicate the player does not have access to that command were changed to remove the permission from the message.**
 This was requested by a couple of admins because they did not want the players to see the internal workings that would otherwise control how the software would behave.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,12 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16b 2024-03-05
+# 3.3.0-alpha.16c 2024-03-05
+
+
+
+**3.3.0-alpha.16c 2024-03-05** 
+
 
 
 * **Bug fix: the check for the time the reset has been going on was incorrect and was fixed.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,10 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16c 2024-03-05
+# 3.3.0-alpha.16c 2024-03-14
+
+
+* **Initial setup of sellall lore filtering**
 
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,8 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16b 2024-02-24** 
 
 
+* **Bug fix: GUI configuration: Found a problem that when configuring the gui initial settings, that there were problems when trying to access mines and ranks when they don't yet exist.**
+
 
 * **Add prison debug option to filter on blockConstraints when regenerating the blocks within the mines.**
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-02-26
 
 
+* **Mine imports: Fix some minor issues to get this to work even better.**
+
+
 * **Mine skip reset: If a mine is reset, send a message to players, but only if the message is defined and not empty: 'skip_reset_message='**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,10 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-02-27
 
 
+* **AutoSell: Bug fix: When autosell and sell on inventory is full was all turned off, it would still sell.**
+This fixes some of the logic to simplify the code, and to fix those issues.
+
+
 * **Mine skip reset messaging: Did not have it hooked up in the correct location, so the skip messages were not happening.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,11 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16c 2024-03-15
+# 3.3.0-alpha.16c 2024-03-29
+
+
+
+* **Localization: If admin adds extra parameters, or other parsing failures, happens on a message, the error will now be trapped and logged to the console without formatting.**
 
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16c 2024-03-15
 
 
+* **Mine Bombs: wrapped up the changes to enable the placement of a mine bomb when using the BlockPlaceEvent which is used when using a block for the bomb's item.**
+
+
 * **Prison ItemStack: remove enchantments from the core ItemStack since prison cannot properly represent it in versions lower than 1.13.x**, plus it was wrong for all spigot versions greater than 1.12.x.
 Added the proper enchantment functions to the SpigotItemStack object.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -18,7 +18,12 @@ These change logs represent the work that has been going on within prison.
 
 
 
-**3.3.0-alpha.16c 2024-03-09** 
+**3.3.0-alpha.16c 2024-03-10** 
+
+
+* **New feature: TopN customization now possible.  The messages and placeholders that you can use are located in the core multi-language files.**
+See the bottom of the files for instructions on usage.
+TopN data is set to delay load so it does not lengthen the startup process.  As such, it now reports that the data is being loaded so it is now clear why there are no entries in the list initially.
 
 
 * **Mines: eliminate a field no longer used: includeInLayerCalculations.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,17 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16c 2024-03-29
+# 3.3.0-alpha.16c 2024-04-07
+
+
+* **Localizable: Secondary placeholders:  Rewrote the whole support of secondary placeholders related to players.***
+Expanded the support by making them generic so other data sources can also have their own custom set of placeholders too.  Such as mines.
+This now supports a new interface that will provide the generic support.
+Player's commands have been modified to pass a RankPlayer object, which supports the new interface.  Non-player commands have not been converted since players will never see those messages (such as admin commands).
+
+
+* **Added a comment in the ranks message files indicating that there is now some support for player based placeholders to farther customize messages.**
+This also fixes an issue with the broadcast messages to use the intended player instead of the target player who is being sent the message.
 
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-03-05
 
 
+* **Block lists: Added the total chance percentage to be displayed with the blocks.**
+
+
 * **File output technique: Changes to how the "replace" existing files works.**
 If the file does not exist, then it opens it to create it, otherwise it truncates it.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -18,7 +18,12 @@ These change logs represent the work that has been going on within prison.
 
 
 
-**3.3.0-alpha.16b 2024-02-22** 
+**3.3.0-alpha.16b 2024-02-24** 
+
+
+
+* **Add prison debug option to filter on blockConstraints when regenerating the blocks within the mines.**
+
 
 * **Bug fix: prison support submit: if the bukkit system cannot extract a file from the jar**, such as plugin.yml, this will prevent the failure of the command.  This will allow the command to continue being processed, but may just skip the extraction.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,11 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16b 2024-03-01
+# 3.3.0-alpha.16b 2024-03-05
+
+
+* **File output technique: Changes to how the "replace" existing files works.**
+If the file does not exist, then it opens it to create it, otherwise it truncates it.
 
 
 * **Mine bombs: Ability to prevent a bomb's blocks from count towards the player's block totals.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -20,6 +20,8 @@ These change logs represent the work that has been going on within prison.
 
 **3.3.0-alpha.16c 2024-03-11** 
 
+* **Mine bombs: add support for BlockPlacementEvent so if someone is using a Block they can use it as the mine bomb's item.**
+
 
 * **Prison's NBT: Add support for using NBTs with bukkit's Block.**
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,9 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16c 2024-03-11** 
 
 
+* **Add support for getting the "hand" from the BlockPlaceEvent.**
+
+
 * **Prison support listeners: added support for listening to and providing dumps for PlayerDropItemEvent, PlayerPickupItemEvent, and BlockPlaceEvent.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,14 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16c 2024-04-20
 
 
+* **Mines messages: Secondary placeholders.  Added support for mines' messages to be able to support secondary placeholders within the language files. NOTE: Not usable at this time.**
+But... this is basically useless.  Within the mines language files, the vast majority of all messages are related to admin messages and are not viewable by the players.
+Therefore the admin-only messages will not support the secondary placeholders since the players will never see them.
+At this time, there are no messages that supports the use of these secondary placeholders, although the feature has been enabled for mines.
+If a need is required, then please reach out and request such features should be enabled.  At this time, effort and work will not be performed blindly upon items that will never be used, so if you see a need for this, I'd be happy to add them since you would have a need.
+
+
+
 * **Placeholder bug: The placeholder 'prison_rankup_cost_percent' uses the calculated value of a percentage, but when used with the placeholder attribute, it was found to use the price instead.**  As such, the actual value returned for the placeholder was incorrect.
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,9 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16c 2024-03-11** 
 
 
+* **Prison's NBT: Add support for using NBTs with bukkit's Block.**
+
+
 * **Add support for getting the "hand" from the BlockPlaceEvent.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,9 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16b 2024-02-24** 
 
 
+* **Prison startup bug: There was an issue with the prison startup when there was an error and prison tried to log the error**, only to find that resources that were needed for logging were not yet loaded nor were their dependencies.  This fixes some of the entanglements to allow the error messages to be properly logged.
+
+
 * **Bug fix: GUI configuration: Found a problem that when configuring the gui initial settings, that there were problems when trying to access mines and ranks when they don't yet exist.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,11 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.16a 2024-02-19
+# 3.3.0-alpha.16b 2024-02-20
+
+
+
+**3.3.0-alpha.16b 2024-02-20** 
 
 
 * **Placeholders: Top player rank was using the wrong ladder, which was incorrectly the prestiges rank and not the default rank.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -18,7 +18,11 @@ These change logs represent the work that has been going on within prison.
 
 
 
-**3.3.0-alpha.16c 2024-03-05** 
+**3.3.0-alpha.16c 2024-03-07** 
+
+
+* **Mine reset: added a force to the reset so it will ignore an existing mine reset and allow a new one to begin.***
+When a mine is being reset, there is no way to actually cancel it.  So this allows a large mine to undergo multiple concurrent resets.  Use at your own risk.
 
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,10 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16b 2024-02-24** 
 
 
+* **Prison Command Handler: using config.yml you can now change all of prison's root commands with 'prisonCommandHandler.command-roots'.**
+Can now map 'prison', 'mines', 'ranks', 'gui', 'sellall' to all new command that you want.
+
+
 * **File saving: alternative technique for saving files. Do not use!**
 This is a more dangerous technique that could possibly result in lost configurations.  This is being provided as a degraded service if the fail-safe technique is not working ideally on a degraded server.
 This should never be used, unless directed by a prison support admin.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,9 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16c 2024-03-11** 
 
 
+* **PlaceholderAPI: Upgrade from v2.11.2 to v2.11.5**
+
+
 * **XSeries: Upgrade from v9.8.0 to v9.9.0**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -16,6 +16,13 @@ These change logs represent the work that has been going on within prison.
 
 # 3.3.0-alpha.16c 2024-03-15
 
+
+* **Sellall: New command:  '/sellall items inspect'**
+This new command will inspect what the player is holding, and dump the details so the admin can see exactly how an item/block is created, including lore and enchantments.
+Eventually this information can be used to enhance the ability to sell and buy non-standard items by allowing the admins to filter on lore, enchantments, and/or NBTs.
+
+
+
 * **SpigotPlayer: Fixed a potential issue if trying to use getRankPlayer() if the ranks module is not enabled.**
 Added a check to ensure it's active.
 We have not seen any reports of issues related to this.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,10 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16c 2024-03-09** 
 
 
+* **Mines: eliminate a field no longer used: includeInLayerCalculations.**
+This was obsoleted with better use of logic.
+
+
 * **Mine resets: Reworked how prison is selecting random blocks per layer, to properly include constraints.**
 The addition of various new features in the past made a mess of the logic, so it's been cleaned up greatly so it now makes sense and should work properly now.
 There is a slight risk, that as blocks are removed from a layer due to reaching it's max constraint value, that future random selections were missing blocks selections and was then inserting AIR. This fixed code now will insert a filler block which has been selected with no constraints, and the largest chance value.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -18,7 +18,7 @@ These change logs represent the work that has been going on within prison.
 
 
 * **Initial setup of sellall lore filtering**
-
+A little clean up.
 
 
 **3.3.0-alpha.16c 2024-03-11** 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16b 2024-03-01
 
 
+* **Mine bombs: Ability to prevent a bomb's blocks from count towards the player's block totals.**
+
+
 * **Sellall and autosell: Refinements were made to the handling of the sellall settings to better stabilize the use of the commands.**  Setting status for the players were moved to the player objects and is now used in all of the related calculations so there is better stability and consistency.
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,11 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16c 2024-03-15
 
 
+
+* **Economy: For economies that prison supports that has a method to check if the player has an account, prison now tries to check if there is an account for the player before trying to use the economy.**
+This could potentially prevent issues or run time failures.
+
+
 * **Prison API: Added a few new functions to work with ItemStacks.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16a 2024-02-19
 
 
+* **ranks ladder: applyRanksCostMultiplier command was changed to allow the value of 'true' to be used along with the value of 'apply'.**  This helps to eliminate some confusion on how the command works.
+
+
 * **Bug fix: Prison command handler.  When players are de-op'd, and they do the commands such as `/ranks help` or `/mines help` it was incorrectly showing other sub commands they did not have access to.**
 This now shows the correct sub commands that they have access to.
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,10 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.16c 2024-03-15
 
 
+* **Prison Player: Added a new sendMessage function using Lists of Strings. ** 
+Added a new function getPlatformPlayer() which gets a bukkit player object if the player is online.  This will consolidate a lot of other duplicate code.
+
+
 * **Mine Bombs: wrapped up the changes to enable the placement of a mine bomb when using the BlockPlaceEvent which is used when using a block for the bomb's item.**
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -21,6 +21,12 @@ These change logs represent the work that has been going on within prison.
 **3.3.0-alpha.16b 2024-02-24** 
 
 
+* **File saving: alternative technique for saving files. Do not use!**
+This is a more dangerous technique that could possibly result in lost configurations.  This is being provided as a degraded service if the fail-safe technique is not working ideally on a degraded server.
+This should never be used, unless directed by a prison support admin.
+
+
+
 * **Prison startup bug: There was an issue with the prison startup when there was an error and prison tried to log the error**, only to find that resources that were needed for logging were not yet loaded nor were their dependencies.  This fixes some of the entanglements to allow the error messages to be properly logged.
 
 

--- a/docs/knownissues_v3.3.x.md
+++ b/docs/knownissues_v3.3.x.md
@@ -13,6 +13,14 @@ Resolved issues have been relocated to:
 * [Known Issues - Resolved](knownissues_v3.2.x_resolved.md)
 
 
+# TODO Items for v3.3.0-alpha.16
+
+
+DONE: Added support for BlockPlaceEvent to allow this - editid - Mine bombs cannot be placed in a mine that is protected by world guard, which is 
+  reporting that the player does not have access.  Had to allow players to place blocks in 
+  mines, which is not appropriate.
+
+
 # TODO Items for v3.3.0-alpha.15
 
 

--- a/docs/prison_changelogs.md
+++ b/docs/prison_changelogs.md
@@ -22,6 +22,7 @@ These build logs represent the work that has been going on within prison.
     - Future updates will be under the v3.3.x release
  
  
+ - [v3.3.3-alpha.17 - 2024-04-20](prison_changelog_v3.3.0-alpha.17.md)&nbsp;&nbsp;
  - [v3.3.3-alpha.16 - 2023-11-18](prison_changelog_v3.3.0-alpha.16.md)&nbsp;&nbsp;
  - [v3.3.3-alpha.15 - 2023-07-07](prison_changelog_v3.3.0-alpha.15.md)&nbsp;&nbsp;
  - [v3.3.3-alpha.14 - 2023-01-23](prison_changelog_v3.3.0-alpha.14.md)&nbsp;&nbsp;

--- a/docs/prison_chnagelog_v3.3.0-alpha.17.md
+++ b/docs/prison_chnagelog_v3.3.0-alpha.17.md
@@ -1,0 +1,655 @@
+[Prison Documents - Table of Contents](prison_docs_000_toc.md)
+
+## Prison Build Logs for v3.3.x
+
+## Build logs
+ - **[v3.3.0-alpha - Current](changelog_v3.3.x.md)**
+ - [v3.2.0 through v3.3.0-alpha.17](prison_changelogs.md)
+ 
+
+These build logs represent the work that has been going on within prison. 
+
+
+# 3.3.0-alpha.17 2024-04-21
+
+
+
+The following is a highlight of changes for the alpha.17 release since the alpha.16 release.
+
+
+* Mines: Added more support for the use of '*all*' for mine names so more of the mine commands will be able to apply to all mines.
+
+
+* **Upgrade XSeries to v9.7.0 from v9.4.0.**
+* **Upgrade XSeries from v9.7.0 to v9.8.0.**
+* **XSeries: Upgrade from v9.8.0 to v9.9.0**
+
+* **Upgrade nbt-api from v2.12.0 to v2.12.2.**
+
+* **PlaceholderAPI: Upgrade from v2.11.2 to v2.11.5**
+
+
+
+* **Breaking change in XSeries: GRASS has been changed to SHORT_GRASS for v20.0.4!** It's disappointing to say the least that after all of these years, XSeries screwed up and pushed a breaking change to their repo.  They should have kept GRASS so they would have remained compatible will all past code and configs that had to refer to GRASS directly, but nope... they opted for causing problems.  Very disappointing.
+Setup a converter to automatically convert all GRASS to SHORT_GRASS as the mines are loaded.
+
+
+
+* **Bug Fix: Mine resets and block constraints.**
+This fixes a few issues with block constrains using min and max, along with exclude from top and bottom too.
+
+
+* **Bug Fix: GUI ranks, mines, and prestiges were not using the default item name correctly.**  It was using the template correctly, but was not translating the use of placeholders.  Only name and tag are supported.
+Mines: `{mineName}` and `{mineTag}`
+Ranks and prestiges: `{rankName}` and `{rankTag}`
+
+
+
+* **config.yml - changed the default values for remapping aliases and restricting players from using commands.**
+The default, which used `/mines tp` was actually causing conflict with normal usage.
+
+
+* **AutoFeatures auto permissions: enable the ability to 'disable' the perms.**  Any op'd player, if perms are enabled, will have these auto features enabled.  There is no other way around this, since this is the correct behavior of OP'd players.
+
+
+* **Mine resets: If a mine reset takes longer than 4 minutes, then that is probably a failure and the mine reset did not complete.**  Therefore, reset the mine reset mutex and try again.  This allows a "crashed" mine reset to auto fix itself if it can.  The 4 minute wait time is LONG, but it will prevent a normal reset from being canceled and restarted in the middle of a restart.
+
+
+* **Performance: Changed the defaults for the mine reset settings to help improve the performance on larger servers.**
+The older settings would allow other commands to backup and it would appear as if there was lag happening, TPS would rarely drop below 20.  This helps to keep performance a little more responsive. 
+The side effect is that there will need to be more "chunks" submitted which could possibly result in longer wall-time for mine resets.
+
+
+* **Mine resets: If a suggested block is null, then set it to air.  This was causing an NPE under some conditions.**
+
+
+* **BlockEvents: Added the ability to update block events**
+instead of deleting them and re-adding them.  Follow directions when using '/mines blockevent update help', or whenever a block event listing is shown in game, you can now click on the commands to auto populate the block event update command... then just edit the needed changes and submit.
+
+
+
+* **Mines: Fixes an issue for when mines are disabled and they are being checked in other processes to see if they are active.**
+If the instance of PrisonMines is null, then it will create a temp instance just to prevent an NPE.
+
+
+
+* **Prison Block change: Add support for display name, which is optional.**
+Setup sellall so it can use the display name now, so renamed items will not be mistaken for vanilla minecraft items.
+More work needs to be done to hook up displayName to other features, such as sellall and add prison block to mines.
+
+
+* **Bug fix: Fixed the command `/mines set accessPermission` where it was apply the given perm to all mines.**
+ Likewise, all mines parameter was failing to do anything.
+
+
+* **NOTE: This alpha version "should" support spigot 20.0.4.**
+After a few days, if no other issues surface pertaining to 20.0.4, or other related plugins, this will be released as a public release.
+
+
+* **Fix issue with BlockEvent's SellAll when isAutoSellIfInventoryIsFullForBLOCKEVENTSPriority feature is enabled.**
+This was not using the correct new functions that checks to see if a player can use autsell, or if they have it temporarily toggled off.  This also checks to see if the player has the correct perms, if perms are enabled for the sellall event.
+
+
+
+
+* **alpha.16a - 2023-12-28**
+  NOTE: I just noticed that alpha.16a was never committed.  So this is not the correct location of when it was set with the local builds.
+  
+
+
+* **updated the help on the `/mines block constraint` to indicate that the layer count is originating from the top, not the bottom.**
+
+
+* **Bug fix: Player manager startup: fixed a problem where all players were being updated** even though they did not have a name change.  Only when name changes are detected are the files updated or when a new player is found.
+
+
+* **Mines set resetTime: fix typo in the description where it shows '*all' instead of '*all*'.**
+
+
+* **ranks ladder: applyRanksCostMultiplier command was changed to allow the value of 'true' to be used along with the value of 'apply'.**  This helps to eliminate some confusion on how the command works.
+
+
+* **Bug fix: Prison command handler.  When players are de-op'd, and they do the commands such as `/ranks help` or `/mines help` it was incorrectly showing other sub commands they did not have access to.**
+This now shows the correct sub commands that they have access to.
+
+
+* **Placeholders: topn players - bug fix.  If a player did not have a prestige rank, then it would cause a NPE when using the `prison_top_player_rank_prestiges_nnn_tp` placeholder.**
+Just check to ensure its not null... if it is, then return an empty string.
+
+
+
+* **Bug fix: prison support submit: if the bukkit system cannot extract a file from the jar**, such as plugin.yml, this will prevent the failure of the command.  This will allow the command to continue being processed, but may just skip the extraction.
+
+
+
+* **Placeholders: Top player rank was using the wrong ladder, which was incorrectly the prestiges rank and not the default rank.**
+Correcting the rank fixed the problem.  This only was an issue if the player did not have a prestige rank.
+
+
+
+* **Bug fix: GUI configuration: Found a problem that when configuring the gui initial settings, that there were problems when trying to access mines and ranks when they don't yet exist.**
+
+
+
+
+* **File saving: alternative technique for saving files. Do not use!**
+This is a more dangerous technique that could possibly result in lost configurations.  This is being provided as a degraded service if the fail-safe technique is not working ideally on a degraded server.
+This should never be used, unless directed by a prison support admin.
+
+
+
+* **Prison startup bug: There was an issue with the prison startup when there was an error and prison tried to log the error**, only to find that resources that were needed for logging were not yet loaded nor were their dependencies.  This fixes some of the entanglements to allow the error messages to be properly logged.
+
+
+
+* **Import Mines: Added the ability to import mines from JetPrisonMines config files.**
+`/mines import jetprisonmines help`
+
+
+* **Prison Command Handler: using config.yml you can now change all of prison's root commands with 'prisonCommandHandler.command-roots'.**
+Can now map 'prison', 'mines', 'ranks', 'gui', 'sellall' to all new command that you want.
+
+
+
+
+**3.3.0-alpha.16b 2024-02-24** 
+
+
+
+* **Mine imports: Fix some minor issues to get this to work even better.**
+
+* **Mines import: prevent the processing of an importing of a mine if there are problems with the mine's name, or locations.**
+
+
+
+* **Mine skip reset: If a mine is reset, send a message to players, but only if the message is defined and not empty: 'skip_reset_message='**
+
+
+
+* **Player sellall Multipliers: Fixed the ranks multiplier to include all ranks that are defined within the sellall multipliers.**
+Added a new function that will gather and list all multipliers that go in to the calculation of the player's total multipliers, which includes the rank multipliers (the sellall multipliers) and also permission based multipliers.
+This detailed list of the individual multipliers, is viewable for each player that is online with the command `/ranks player <player>` and reveals the actual details of how it's calculated.
+
+
+
+* **AutoSell: Bug fix: When autosell and sell on inventory is full was all turned off, it would still sell.**
+This fixes some of the logic to simplify the code, and to fix those issues.
+
+
+* **Mine skip reset messaging: Did not have it hooked up in the correct location, so the skip messages were not happening.**
+
+
+* **Mine reset: Under heavy load when performing a mine import, there were seen occasionally errors with concurrent modification errors.**
+Code was changed to minimize that possibility.
+
+
+* **Sellall and GUI message failures: a number of messages that would indicate the player does not have access to that command were changed to remove the permission from the message.**
+This was requested by a couple of admins because they did not want the players to see the internal workings that would otherwise control how the software would behave.
+
+
+
+* **Block lists: Added the total chance percentage to be displayed with the blocks.**
+
+
+* **File output technique: Changes to how the "replace" existing files works.**
+If the file does not exist, then it opens it to create it, otherwise it truncates it.
+
+
+* **Mine bombs: Ability to prevent a bomb's blocks from count towards the player's block totals.**
+
+
+* **Sellall and autosell: Refinements were made to the handling of the sellall settings to better stabilize the use of the commands.**  Setting status for the players were moved to the player objects and is now used in all of the related calculations so there is better stability and consistency.
+
+
+
+* **Bug fix: the check for the time the reset has been going on was incorrect and was fixed.**
+Also all the code for submitting the reset task was moved in to the mutext.  Now, if the reset got hung up, this will properly terminate it and resubmit it.
+
+
+* **File format: Eliminate the check for file types since there is only one.**
+Currently there isn't a setting to specify what it should be.
+
+
+* **Mines block layerStats: Added a new command that shows which blocks are in each layer in the mine.**
+There are a lot of future enhancements that can be added to this command, such as checking the actual blocks to see if they are still there, or if there was a problem with the spawning of the blocks.
+
+
+* **Mines block layer: Added colors for same IDs so it's easier to read.**  Added a check that sees what block actually exists.  If counts of what should have spawned match whats in the mine for that layer, then it shows only one number.  It shows two numbers if a block's intended spawn does not match what's in the mine.
+
+
+* **Mine reset: added a force to the reset so it will ignore an existing mine reset and allow a new one to begin.***
+When a mine is being reset, there is no way to actually cancel it.  So this allows a large mine to undergo multiple concurrent resets.  Use at your own risk.
+
+
+
+* **Mine resets: Reworked how prison is selecting random blocks per layer, to properly include constraints.**
+The addition of various new features in the past made a mess of the logic, so it's been cleaned up greatly so it now makes sense and should work properly now.
+There is a slight risk, that as blocks are removed from a layer due to reaching it's max constraint value, that future random selections were missing blocks selections and was then inserting AIR. This fixed code now will insert a filler block which has been selected with no constraints, and the largest chance value.
+
+
+* **mines block layerStats: rewrote to improve and get rid of the collection manipulations.**
+Found potential problem with air being inserted in to mines.
+Renamed a lot of uses of Location objects to include the name "location" in their variable names instead of "block".
+
+
+
+* **New feature: TopN customization now possible.  The messages and placeholders that you can use are located in the core multi-language files.**
+See the bottom of the files for instructions on usage.
+TopN data is set to delay load so it does not lengthen the startup process.  As such, it now reports that the data is being loaded so it is now clear why there are no entries in the list initially.
+
+
+
+* **Prison support listeners: added support for listening to and providing dumps for PlayerDropItemEvent, PlayerPickupItemEvent, and BlockPlaceEvent.**
+
+
+* **Promote & Demote: Improved upon reporting issues with the command.**
+There were few situations where the command would exit without reporting why, which was leading to difficulties with using the command effectively. 
+
+
+* **Mine bombs: add support for BlockPlacementEvent so if someone is using a Block they can use it as the mine bomb's item.**
+
+
+* **Prison's NBT: Add support for using NBTs with bukkit's Block.**
+
+
+
+* **PlaceholderAPI: Upgrade from v2.11.2 to v2.11.5**
+
+
+* **XSeries: Upgrade from v9.8.0 to v9.9.0**
+
+
+
+**3.3.0-alpha.16c 2024-03-11** 
+
+
+
+* **Mine Bombs: wrapped up the changes to enable the placement of a mine bomb when using the BlockPlaceEvent which is used when using a block for the bomb's item.**
+
+
+* **Prison ItemStack: remove enchantments from the core ItemStack since prison cannot properly represent it in versions lower than 1.13.x**, plus it was wrong for all spigot versions greater than 1.12.x.
+Added the proper enchantment functions to the SpigotItemStack object.
+
+
+
+
+* **Sellall: New command:  '/sellall items inspect'**
+This new command will inspect what the player is holding, and dump the details so the admin can see exactly how an item/block is created, including lore and enchantments.
+Eventually this information can be used to enhance the ability to sell and buy non-standard items by allowing the admins to filter on lore, enchantments, and/or NBTs.
+
+
+
+* **SpigotPlayer: Fixed a potential issue if trying to use getRankPlayer() if the ranks module is not enabled.**
+Added a check to ensure it's active.
+We have not seen any reports of issues related to this.
+
+
+
+
+
+* **Prison API: Added a few new functions to work with ItemStacks.**
+
+
+
+
+* **Localization: If admin adds extra parameters, or other parsing failures, happens on a message, the error will now be trapped and logged to the console without formatting.**
+
+
+
+* **Economy: For economies that prison supports that has a method to check if the player has an account, prison now tries to check if there is an account for the player before trying to use the economy.**
+This could potentially prevent issues or run time failures.
+
+
+* **Player Manager: Secondary Placeholders:  Setup the secondary placeholder support on the PlayerManager, but it has not been enabled yet** since secondary placeholders on placeholders do not make a lot of sense because each placeholder is only one value and they cannot contain alternative text.  At least not yet.
+
+
+* **Localizable: Secondary placeholders:  Rewrote the whole support of secondary placeholders related to players.***
+Expanded the support by making them generic so other data sources can also have their own custom set of placeholders too.  Such as mines.
+This now supports a new interface that will provide the generic support.
+Player's commands have been modified to pass a RankPlayer object, which supports the new interface.  Non-player commands have not been converted since players will never see those messages (such as admin commands).
+
+
+
+* **Placeholder bug: The placeholder 'prison_rankup_cost_percent' uses the calculated value of a percentage, but when used with the placeholder attribute, it was found to use the price instead.**  As such, the actual value returned for the placeholder was incorrect.
+
+
+
+* **Mines messages: Secondary placeholders.  Added support for mines' messages to be able to support secondary placeholders within the language files. NOTE: Not usable at this time.**
+But... this is basically useless.  Within the mines language files, the vast majority of all messages are related to admin messages and are not viewable by the players.
+Therefore the admin-only messages will not support the secondary placeholders since the players will never see them.
+At this time, there are no messages that supports the use of these secondary placeholders, although the feature has been enabled for mines.
+If a need is required, then please reach out and request such features should be enabled.  At this time, effort and work will not be performed blindly upon items that will never be used, so if you see a need for this, I'd be happy to add them since you would have a need.
+
+
+
+
+
+
+* * * * * * * * * * *
+
+
+
+* **Mines messages: Secondary placeholders.  Added support for mines' messages to be able to support secondary placeholders within the language files. NOTE: Not usable at this time.**
+But... this is basically useless.  Within the mines language files, the vast majority of all messages are related to admin messages and are not viewable by the players.
+Therefore the admin-only messages will not support the secondary placeholders since the players will never see them.
+At this time, there are no messages that supports the use of these secondary placeholders, although the feature has been enabled for mines.
+If a need is required, then please reach out and request such features should be enabled.  At this time, effort and work will not be performed blindly upon items that will never be used, so if you see a need for this, I'd be happy to add them since you would have a need.
+
+
+
+* **Placeholder bug: The placeholder 'prison_rankup_cost_percent' uses the calculated value of a percentage, but when used with the placeholder attribute, it was found to use the price instead.**  As such, the actual value returned for the placeholder was incorrect.
+
+
+* **Player Manager: Secondary Placeholders:  Setup the secondary placeholder support on the PlayerManager, but it has not been enabled yet** since secondary placeholders on placeholders do not make a lot of sense because each placeholder is only one value and they cannot contain alternative text.  At least not yet.
+
+
+* **Localizable: Secondary placeholders:  Rewrote the whole support of secondary placeholders related to players.***
+Expanded the support by making them generic so other data sources can also have their own custom set of placeholders too.  Such as mines.
+This now supports a new interface that will provide the generic support.
+Player's commands have been modified to pass a RankPlayer object, which supports the new interface.  Non-player commands have not been converted since players will never see those messages (such as admin commands).
+
+
+* **Added a comment in the ranks message files indicating that there is now some support for player based placeholders to farther customize messages.**
+This also fixes an issue with the broadcast messages to use the intended player instead of the target player who is being sent the message.
+
+
+
+* **Localization: If admin adds extra parameters, or other parsing failures, happens on a message, the error will now be trapped and logged to the console without formatting.**
+
+
+
+* **Economy: For economies that prison supports that has a method to check if the player has an account, prison now tries to check if there is an account for the player before trying to use the economy.**
+This could potentially prevent issues or run time failures.
+
+
+* **Prison API: Added a few new functions to work with ItemStacks.**
+
+
+
+* **Players: Shift the function of getting a player object to the Player classes, such as CommandSender.**
+This is to simplify the code and to put the functionality in one location.
+
+
+
+* **Sellall: New command:  '/sellall items inspect'**
+This new command will inspect what the player is holding, and dump the details so the admin can see exactly how an item/block is created, including lore and enchantments.
+Eventually this information can be used to enhance the ability to sell and buy non-standard items by allowing the admins to filter on lore, enchantments, and/or NBTs.
+
+
+
+* **SpigotPlayer: Fixed a potential issue if trying to use getRankPlayer() if the ranks module is not enabled.**
+Added a check to ensure it's active.
+We have not seen any reports of issues related to this.
+
+
+
+* **Prison Player: Added a new sendMessage function using Lists of Strings. ** 
+Added a new function getPlatformPlayer() which gets a bukkit player object if the player is online.  This will consolidate a lot of other duplicate code.
+
+
+* **Mine Bombs: wrapped up the changes to enable the placement of a mine bomb when using the BlockPlaceEvent which is used when using a block for the bomb's item.**
+
+
+* **Prison ItemStack: remove enchantments from the core ItemStack since prison cannot properly represent it in versions lower than 1.13.x**, plus it was wrong for all spigot versions greater than 1.12.x.
+Added the proper enchantment functions to the SpigotItemStack object.
+
+
+* **Initial setup of sellall lore filtering**
+A little clean up.
+
+
+**3.3.0-alpha.16c 2024-03-11** 
+
+
+* **PlaceholderAPI: Upgrade from v2.11.2 to v2.11.5**
+
+
+* **XSeries: Upgrade from v9.8.0 to v9.9.0**
+
+
+* **Mine bombs: add support for BlockPlacementEvent so if someone is using a Block they can use it as the mine bomb's item.**
+
+
+* **Prison's NBT: Add support for using NBTs with bukkit's Block.**
+
+
+* **Add support for getting the "hand" from the BlockPlaceEvent.**
+
+
+* **Prison support listeners: added support for listening to and providing dumps for PlayerDropItemEvent, PlayerPickupItemEvent, and BlockPlaceEvent.**
+
+
+* **Promote & Demote: Improved upon reporting issues with the command.**
+There were few situations where the command would exit without reporting why, which was leading to difficulties with using the command effectively. 
+
+
+* **New feature: TopN customization now possible.  The messages and placeholders that you can use are located in the core multi-language files.**
+See the bottom of the files for instructions on usage.
+TopN data is set to delay load so it does not lengthen the startup process.  As such, it now reports that the data is being loaded so it is now clear why there are no entries in the list initially.
+
+
+* **Mines: eliminate a field no longer used: includeInLayerCalculations.**
+This was obsoleted with better use of logic.
+
+
+* **Mine resets: Reworked how prison is selecting random blocks per layer, to properly include constraints.**
+The addition of various new features in the past made a mess of the logic, so it's been cleaned up greatly so it now makes sense and should work properly now.
+There is a slight risk, that as blocks are removed from a layer due to reaching it's max constraint value, that future random selections were missing blocks selections and was then inserting AIR. This fixed code now will insert a filler block which has been selected with no constraints, and the largest chance value.
+
+
+* **mines block layerStats: rewrote to improve and get rid of the collection manipulations.**
+Found potential problem with air being inserted in to mines.
+Renamed a lot of uses of Location objects to include the name "location" in their variable names instead of "block".
+
+
+* **Mines block layer: Added colors for same IDs so it's easier to read.**  Added a check that sees what block actually exists.  If counts of what should have spawned match whats in the mine for that layer, then it shows only one number.  It shows two numbers if a block's intended spawn does not match what's in the mine.
+
+
+* **Mine reset: added a force to the reset so it will ignore an existing mine reset and allow a new one to begin.***
+When a mine is being reset, there is no way to actually cancel it.  So this allows a large mine to undergo multiple concurrent resets.  Use at your own risk.
+
+
+
+* **Bug fix: the check for the time the reset has been going on was incorrect and was fixed.**
+Also all the code for submitting the reset task was moved in to the mutext.  Now, if the reset got hung up, this will properly terminate it and resubmit it.
+
+
+* **File format: Eliminate the check for file types since there is only one.**
+Currently there isn't a setting to specify what it should be.
+
+
+* **Mines block layerStats: Added a new command that shows which blocks are in each layer in the mine.**
+There are a lot of future enhancements that can be added to this command, such as checking the actual blocks to see if they are still there, or if there was a problem with the spawning of the blocks.
+
+
+* **Block lists: Added the total chance percentage to be displayed with the blocks.**
+
+
+* **File output technique: Changes to how the "replace" existing files works.**
+If the file does not exist, then it opens it to create it, otherwise it truncates it.
+
+
+* **Mine bombs: Ability to prevent a bomb's blocks from count towards the player's block totals.**
+
+
+* **Sellall and autosell: Refinements were made to the handling of the sellall settings to better stabilize the use of the commands.**  Setting status for the players were moved to the player objects and is now used in all of the related calculations so there is better stability and consistency.
+
+
+* **Mines import: prevent the processing of an importing of a mine if there are problems with the mine's name, or locations.**
+
+
+* **AutoSell: Bug fix: When autosell and sell on inventory is full was all turned off, it would still sell.**
+This fixes some of the logic to simplify the code, and to fix those issues.
+
+
+* **Mine skip reset messaging: Did not have it hooked up in the correct location, so the skip messages were not happening.**
+
+
+* **Mine reset: Under heavy load when performing a mine import, there were seen occasionally errors with concurrent modification errors.**
+Code was changed to minimize that possibility.
+
+
+* **Sellall and GUI message failures: a number of messages that would indicate the player does not have access to that command were changed to remove the permission from the message.**
+This was requested by a couple of admins because they did not want the players to see the internal workings that would otherwise control how the software would behave.
+
+
+
+* **Mine imports: Fix some minor issues to get this to work even better.**
+
+
+* **Mine skip reset: If a mine is reset, send a message to players, but only if the message is defined and not empty: 'skip_reset_message='**
+
+
+
+* **Player sellall Multipliers: Fixed the ranks multiplier to include all ranks that are defined within the sellall multipliers.**
+Added a new function that will gather and list all multipliers that go in to the calculation of the player's total multipliers, which includes the rank multipliers (the sellall multipliers) and also permission based multipliers.
+This detailed list of the individual multipliers, is viewable for each player that is online with the command `/ranks player <player>` and reveals the actual details of how it's calculated.
+
+
+
+**3.3.0-alpha.16b 2024-02-24** 
+
+
+* **Import Mines: Added the ability to import mines from JetPrisonMines config files.**
+`/mines import jetprisonmines help`
+
+
+* **Prison Command Handler: using config.yml you can now change all of prison's root commands with 'prisonCommandHandler.command-roots'.**
+Can now map 'prison', 'mines', 'ranks', 'gui', 'sellall' to all new command that you want.
+
+
+* **File saving: alternative technique for saving files. Do not use!**
+This is a more dangerous technique that could possibly result in lost configurations.  This is being provided as a degraded service if the fail-safe technique is not working ideally on a degraded server.
+This should never be used, unless directed by a prison support admin.
+
+
+
+* **Prison startup bug: There was an issue with the prison startup when there was an error and prison tried to log the error**, only to find that resources that were needed for logging were not yet loaded nor were their dependencies.  This fixes some of the entanglements to allow the error messages to be properly logged.
+
+
+* **Bug fix: GUI configuration: Found a problem that when configuring the gui initial settings, that there were problems when trying to access mines and ranks when they don't yet exist.**
+
+
+* **Add prison debug option to filter on blockConstraints when regenerating the blocks within the mines.**
+
+
+* **Bug fix: prison support submit: if the bukkit system cannot extract a file from the jar**, such as plugin.yml, this will prevent the failure of the command.  This will allow the command to continue being processed, but may just skip the extraction.
+
+
+
+* **Placeholders: Top player rank was using the wrong ladder, which was incorrectly the prestiges rank and not the default rank.**
+Correcting the rank fixed the problem.  This only was an issue if the player did not have a prestige rank.
+
+
+
+* **Mines set resetTime: fix typo in the description where it shows '*all' instead of '*all*'.**
+
+
+* **ranks ladder: applyRanksCostMultiplier command was changed to allow the value of 'true' to be used along with the value of 'apply'.**  This helps to eliminate some confusion on how the command works.
+
+
+* **Bug fix: Prison command handler.  When players are de-op'd, and they do the commands such as `/ranks help` or `/mines help` it was incorrectly showing other sub commands they did not have access to.**
+This now shows the correct sub commands that they have access to.
+
+
+* **Placeholders: topn players - bug fix.  If a player did not have a prestige rank, then it would cause a NPE when using the `prison_top_player_rank_prestiges_nnn_tp` placeholder.**
+Just check to ensure its not null... if it is, then return an empty string.
+
+
+* **Bug fix: Player manager startup: fixed a problem where all players were being updated** even though they did not have a name change.  Only when name changes are detected are the files updated or when a new player is found.
+
+
+* **Add debug statements to identify how each block was calculated during a mine reset.**
+
+
+* **Bug fix: block constraints: fix an issue with the selection of lower limits.**
+
+
+* **updated the help on the `/mines block constraint` to indicate that the layer count is originating from the top, not the bottom.**
+
+
+* **alpha.16a - 2023-12-28**
+  NOTE: I just noticed that alpha.16a was never committed.  So this is not the correct location of when it was set with the local builds.
+  
+
+* **Mines: Fixes an issue for when mines are disabled and they are being checked in other processes to see if they are active.**
+If the instance of PrisonMines is null, then it will create a temp instance just to prevent an NPE.
+
+
+* **Mines unit tests: Setup a new constructor for mines that is only to be used with unit tests which allows the mines to be created,** but it does not initialize them since such tasks and processes are not needed in the unit tests. 
+As a side effect, these two unit test run much faster since it's not trying to setup tasks.
+
+
+* **Prison Block change: Add support for display name, which is optional.**
+Setup sellall so it can use the display name now, so renamed items will not be mistaken for vanilla minecraft items.
+More work needs to be done to hoo up displayName to other features, such as sellall and add prison block to mines.
+
+
+* **Bug fix: Fixed the command `/mines set accessPermission` where it was apply the given perm to all mines.**
+ Likewise, all mines parameter was failing to do anything.
+
+
+* **NOTE: This alpha version "should" support spigot 20.0.4.**
+After a few days, if no other issues surface pertaining to 20.0.4, or other related plugins, this will be released as a public release.
+
+
+* **Fix issue with BlockEvent's SellAll when isAutoSellIfInventoryIsFullForBLOCKEVENTSPriority feature is enabled.**
+This was not using the correct new functions that checks to see if a player can use autsell, or if they have it temporarily toggled off.  This also checks to see if the player has the correct perms, if perms are enabled for the sellall event.
+
+
+* **Breaking change in XSeries: GRASS has been changed to SHORT_GRASS for v20.0.4!** It's disappointing to say the least that after all of these damn years, XSeries screwed up and pushed a breaking change to their repo.  They should have kept GRASS so they would have remained compatible will all past code and configs that had to refer to GRASS directly, but nope... they opted for causing problems.  Very disappointing.
+Setup a converter to automatically convert all GRASS to SHORT_GRASS as the mines are loaded.
+
+
+
+* **Upgrade XSeries from v9.7.0 to v9.8.0.**
+* **Upgrade nbt-api from v2.12.0 to v2.12.2.**
+
+
+* **config.yml - changed the default values for remapping aliases and restricting players from using commands.**
+The default, which used `/mines tp` was actually causing conflict with normal usage.
+
+
+* **AutoFeatures auto permissions: enable the ability to 'disable' the perms.**  Any op'd player, if perms are enabled, will have these auto features enabled.  There is no other way around this, since this is the correct behavior of OP'd players.
+
+
+* **Mine resets: If a mine reset takes longer than 4 minutes, then that is probably a failure and the mine reset did not complete.**  Therefore, reset the mine reset mutex and try again.  This allows a "crashed" mine reset to auto fix itself if it can.  The 4 minute wait time is LONG, but it will prevent a normal reset from being canceled and restarted in the middle of a restart.
+
+
+* **Performance: Changed the defaults for the mine reset settings to help improve the performance on larger servers.**
+The older settings would allow other commands to backup and it would appear as if there was lag happening, TPS would rarely drop below 20.  This helps to keep performance a little more responsive. 
+The side effect is that there will need to be more "chunks" submitted which could possibly result in longer wall-time for mine resets.
+
+
+* **Mine resets: If a suggested block is null, then set it to air.  This was causing an NPE under some conditions.**
+
+
+* **BlockEvents: Added the ability to update block events**
+instead of deleting them and re-adding them.  Follow directions when using '/mines blockevent update help', or whenever a block event listing is shown in game, you can now click on the commands to auto populate the block event update command... then just edit the needed changes and submit.
+
+
+* **Upgrade XSeries to v9.7.0 from v9.4.0.**
+
+
+* **Bug Fix: Mine resets and block constraints.**
+This fixes a few issues with block constrains using min and max, along with exclude from top and bottom too.
+
+
+* **Bug Fix: GUI ranks, mines, and prestiges were not using the default item name correctly.**  It was using the template correctly, but was not translating the use of placeholders.  Only name and tag are supported.
+Mines: `{mineName}` and `{mineTag}`
+Ranks and prestiges: `{rankName}` and `{rankTag}`
+
+
+* **Mines: Added support for '*all*' for mine names for the following mine commands: resetDelay, resetThreshhold, notificationPerm, and accessPermission**
+
+
+* **Localizable: Bug fix. Blanks were being removed by the use of trim() so the spaces were being ignored.**
+
+
+**v3.3.0-alpha.16 2023-11-18**
+
+* Update change logs for v3.3.0-alpha.16
+
+
+
+

--- a/docs/prison_docs_101_setting_up_mines.md
+++ b/docs/prison_docs_101_setting_up_mines.md
@@ -6,7 +6,7 @@
 
 This document provides some highlights to how to setup mines.  It is a work in progress so check back for more information.
 
-*Documented updated: 2023-11-26*
+*Documented updated: 2024-03-11*
 
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">
 
@@ -20,6 +20,12 @@ As a side note, if you installed prison, and it appears like it may not be worki
 
 Prison has a list of suggested plugins that works well with Prison, and a few that do not work at all with Prison.  Please see the following document for a list of suggested plugins.  If you have a favorite plugin that works well with Prison and it's not in that list, then please reach out to us in our discord server and make a suggestion for it to be added. 
 [Setting up Prison - The Basics](prison_docs_012_setting_up_prison_basics.md)
+
+
+**New Command:**
+
+`/mines block layerStats help`
+This new command will provide a layer by layer inspection of what blocks were assigned to a mine, versus what is actually in the mine currently.  This is useful when confirming block constraints are working correctly, or if another block was not spawning as expected, such that there is too much AIR.
 
 
 

--- a/docs/prison_docs_111_mine_commands.md
+++ b/docs/prison_docs_111_mine_commands.md
@@ -6,6 +6,7 @@
 
 This document provides information how to setup and use Mine Commands.
 
+*Documented updated: 2024-03-11*
 
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">
 
@@ -19,6 +20,14 @@ This document will show a simple example, but your imagination can take it to th
 
 My personal goals to use this new feature was to dynamically build a large forest.  Then upon reset, it would erase all the trees and leaves, including any that grew outside of the mine, then randomly plant new trees.  The results would be a new random forest that would be generated each time.  Unfortunately, I have most of the details worked out on how it will work, but not 100% done yet, so I do not have this example to share at this time. :( 
   - Blue
+
+
+
+**New Command:**
+
+`/mines block layerStats help`
+This new command will provide a layer by layer inspection of what blocks were assigned to a mine, versus what is actually in the mine currently.  This is useful when confirming block constraints are working correctly, or if another block was not spawning as expected, such that there is too much AIR.
+
 
 
 <hr style="height:1px; border:none; color:#aaf; background-color:#aaf;">

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.3.0-alpha.16a
+version=3.3.0-alpha.16b
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.3.0-alpha.16b
+version=3.3.0-alpha.16c
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.3.0-alpha.16c
+version=3.3.0-alpha.17
 
 
 

--- a/prison-core/build.gradle
+++ b/prison-core/build.gradle
@@ -32,6 +32,8 @@ repositories {
 dependencies {
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
 
+
+	// https://github.com/InstantlyMoist/privatebin-java-api
 	//implementation 'com.github.InstantlyMoist:privatebin-java-api:1.0.2'
 
 	//implementation 'org.json:json:20230227'

--- a/prison-core/src/main/java/tech/mcprison/prison/Prison.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/Prison.java
@@ -213,7 +213,13 @@ public class Prison
     		
     	if ( this.localeManager == null ) {
     		
-    		this.localeManager = new LocaleManager(this, "lang/core");
+    		synchronized ( this ) {
+    			if ( this.localeManager == null ) {
+				
+    				this.localeManager = new LocaleManager(this, "lang/core");
+    			}
+			}
+    		
     	}
         return localeManager;
     }
@@ -228,7 +234,13 @@ public class Prison
     public File getModuleDataFolder() {
     	
     	if ( moduleDataFolder == null ) {
-    		this.moduleDataFolder = Module.setupModuleDataFolder( "core" );
+    		if ( this.localeManager == null ) {
+    			if ( moduleDataFolder == null ) {
+    				
+    				this.moduleDataFolder = Module.setupModuleDataFolder( "core" );
+    				
+    			}
+    		}
     	}
         return moduleDataFolder;
     }
@@ -237,18 +249,37 @@ public class Prison
     	this.platform = platform;
     }
     
+    
+    
+    
     /**
      * Initializes prison-core. In the implementations, this should be called when the plugin is
      * enabled. After this is called, every getter in this class will return a value.
      * <p>
      * Note that modules <b>should not call this method</b>. This is solely for the implementations.
      */
-    public boolean init(Platform platform, String minecraftVersion, File dataFolder ) {
+    public void init(Platform platform, String minecraftVersion ) {
+    	long startTime = System.currentTimeMillis();
+    	
+    	
+    	this.platform = platform;
+    	this.minecraftVersion = minecraftVersion;
+    	
+    }
+    
+    
+    /**
+     * Initializes prison-core. In the implementations, this should be called when the plugin is
+     * enabled. After this is called, every getter in this class will return a value.
+     * <p>
+     * Note that modules <b>should not call this method</b>. This is solely for the implementations.
+     */
+    public boolean init( File dataFolder ) {
         long startTime = System.currentTimeMillis();
 
         
-        this.platform = platform;
-        this.minecraftVersion = minecraftVersion;
+//        this.platform = platform;
+//        this.minecraftVersion = minecraftVersion;
         
         this.dataFolder = dataFolder;
         

--- a/prison-core/src/main/java/tech/mcprison/prison/PrisonCommand.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/PrisonCommand.java
@@ -2019,7 +2019,8 @@ public class PrisonCommand
 			description = "Provides a detailed list of all registered event listeners for" +
 					"the various event types.  BlockBreak listeners will include all " +
 					"listeners that are being monitored within auto features. " +
-				"[all, blockBreak, chat, playerInteract]"
+				"[all, blockBreak, blockPlace, chat, playerDropItem, "
+							+ "playerPickupItem, playerInteract]"
 					) String listener
     		) {
 		

--- a/prison-core/src/main/java/tech/mcprison/prison/PrisonCommand.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/PrisonCommand.java
@@ -1126,7 +1126,7 @@ public class PrisonCommand
     		@Arg(name = "targets", def = " ",
     				description = "Optional. Enable or disable a debugging target, or set a count down timer. " +
     					"[on, off, targets, (count-down-timer), selective, jarScan, " +
-    					"testPlayerUtil, testLocale, rankup, player=<playerName> ] " +
+    					"testPlayerUtil, testLocale, rankup, blockConstraints, player=<playerName> ] " +
     				"Use 'targets' to list all available targets.  Use 'on' or 'off' to toggle " +
     				"on and off individual targets, or 'all' targets if no target is specified. " +
     				"If any targets are enabled, then debug in general will be enabled. Selective will only " +

--- a/prison-core/src/main/java/tech/mcprison/prison/PrisonCommand.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/PrisonCommand.java
@@ -1535,7 +1535,21 @@ public class PrisonCommand
     		
     		PrisonPasteChat pasteChat = new PrisonPasteChat( getSupportName(), getSupportURLs() );
     		
-    		String helpURL = pasteChat.post( text.toString() );
+    		String helpURL = "(Failure in running the commmand.)";
+    				
+			try {
+				helpURL = pasteChat.post( text.toString() );
+			} 
+			catch (Exception e) {
+				Output.get().logRaw( 
+						
+					String.format(
+						"Failed to paste support info to the support server: %s  "
+						+ "raw message: [%s]", 
+						e.getMessage(),
+						text.toString()
+							) );
+			}
     		
     		getSupportURLs().put( "Submit version:", helpURL );
     		

--- a/prison-core/src/main/java/tech/mcprison/prison/bombs/MineBombData.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/bombs/MineBombData.java
@@ -204,6 +204,12 @@ public class MineBombData {
 	
 	
 	/**
+	 * 
+	 */
+	private boolean applyToPlayersBlockCount = true;
+	
+	
+	/**
 	 * <p>Internal just to indicated if a mine bomb is activated or not.
 	 * This has not purpose if used in a save file.
 	 * </p>
@@ -274,6 +280,9 @@ public class MineBombData {
 		this.autosell = false;
 		this.customModelData = 0;
 		
+		
+		this.applyToPlayersBlockCount = true;
+		
 	}
 	
 	
@@ -326,6 +335,7 @@ public class MineBombData {
 			cloned.getPreventedMines().add( mine );
 		}
 		
+		cloned.setApplyToPlayersBlockCount( isApplyToPlayersBlockCount() );
 		
 		for ( MineBombEffectsData soundEffect : getSoundEffects() ) 
 		{
@@ -539,6 +549,13 @@ public class MineBombData {
 	}
 	public void setActivated( boolean activated ) {
 		this.activated = activated;
+	}
+
+	public boolean isApplyToPlayersBlockCount() {
+		return applyToPlayersBlockCount;
+	}
+	public void setApplyToPlayersBlockCount(boolean applyToPlayersBlockCount) {
+		this.applyToPlayersBlockCount = applyToPlayersBlockCount;
 	}
 
 	public TreeSet<MineBombEffectsData> getSoundEffects() {

--- a/prison-core/src/main/java/tech/mcprison/prison/bombs/MineBombsConfigData.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/bombs/MineBombsConfigData.java
@@ -16,7 +16,7 @@ public class MineBombsConfigData
 	 * data.
 	 * </p>
 	 */
-	public static final int MINE_BOMB_DATA_FORMAT_VERSION = 2;
+	public static final int MINE_BOMB_DATA_FORMAT_VERSION = 3;
 	
 	private int dataFormatVersion = 0;
 	

--- a/prison-core/src/main/java/tech/mcprison/prison/commands/BaseCommands.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/commands/BaseCommands.java
@@ -23,10 +23,10 @@ public abstract class BaseCommands
 	}
 	
 
-	public Player getPlayer( CommandSender sender ) {
-		Optional<Player> player = Prison.get().getPlatform().getPlayer( sender.getName() );
-		return player.isPresent() ? player.get() : null;
-	}
+//	public Player getPlayer( CommandSender sender ) {
+//		Optional<Player> player = Prison.get().getPlatform().getPlayer( sender.getName() );
+//		return player.isPresent() ? player.get() : null;
+//	}
     
     /**
      * <p>Gets a player by name.  If the player is not online, then try to get them from 

--- a/prison-core/src/main/java/tech/mcprison/prison/commands/CommandHandler.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/commands/CommandHandler.java
@@ -801,19 +801,28 @@ public class CommandHandler {
     	
     	if ( !sender.isOp() ) {
     		
-        	String exRAKey = "prisonCommandHandler.exclude-non-ops.exclude-related-aliases";
-        	boolean excludeRelatedAliases = getConfigBoolean( exRAKey );
-        			
-        	String sLabelAlias = !excludeRelatedAliases || rootCommand.getParentOfAlias() == null ? 
-        			null : rootCommand.getParentOfAlias().getCompleteLabel();
-        	
-    		    		
-    		commandAccessPermChecks( sender, rootCommand, label, results );
+    		boolean hasAccess = rootCommand.testPermission(sender);
     		
-    		if ( results.isAccess() && sLabelAlias != null ) {
-
-    			commandAccessPermChecks( sender, rootCommand.getParentOfAlias(), sLabelAlias, results );
+    		if ( !hasAccess ) {
+    			results.setAccess( false );
     		}
+    		else {
+    			
+    			String exRAKey = "prisonCommandHandler.exclude-non-ops.exclude-related-aliases";
+    			boolean excludeRelatedAliases = getConfigBoolean( exRAKey );
+    			
+    			String sLabelAlias = !excludeRelatedAliases || rootCommand.getParentOfAlias() == null ? 
+    					null : rootCommand.getParentOfAlias().getCompleteLabel();
+    			
+    			
+    			commandAccessPermChecks( sender, rootCommand, label, results );
+    			
+    			if ( results.isAccess() && sLabelAlias != null ) {
+    				
+    				commandAccessPermChecks( sender, rootCommand.getParentOfAlias(), sLabelAlias, results );
+    			}
+    		}
+    		
 
     	}
     	

--- a/prison-core/src/main/java/tech/mcprison/prison/file/FileIO.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/file/FileIO.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
@@ -85,30 +86,85 @@ public abstract class FileIO
 //			String tempFileName = file.getName() + "." + getTimestampFormat() + ".tmp";
 //			File tempFile = new File(file.getParentFile(), tempFileName);
 			
-			try
-			{
-				// Write as a .tmp file:
+			boolean disableAdvancedSaves = 
+					Prison.get().getPlatform().getConfigBooleanFalse( 
+							"storage.file.disable-advanced-saves.enabled" );
+			
+			if ( !disableAdvancedSaves ) {
 				
-				// Add json data to lines, splitting on \n:
-				List<String> lines = Arrays.asList( data.split( "\n" ));
-				
-				// Write as an UTF-8 stream:
-				Files.write( tempFile.toPath(), lines, StandardCharsets.UTF_8 );
-				
-//				Files.write( tempFile.toPath(), data.getBytes() );
-				
-				// If original target exists, then delete it:
-				if ( file.exists() )
+				try
 				{
-					file.delete();
+					// Write as a .tmp file:
+					
+					// Add json data to lines, splitting on \n:
+					List<String> lines = Arrays.asList( data.split( "\n" ));
+					
+					// Write as an UTF-8 stream:
+					Files.write( tempFile.toPath(), lines, StandardCharsets.UTF_8 );
+					
+//				Files.write( tempFile.toPath(), data.getBytes() );
+					
+					// If original target exists, then delete it:
+					if ( file.exists() )
+					{
+						file.delete();
+					}
+					
+					tempFile.renameTo( file );
 				}
+				catch ( IOException e )
+				{
+					logException( "Failed to create file", file, e );
+				}
+			}
+			else {
 				
-				tempFile.renameTo( file );
+				boolean keepTempFiles = 
+						Prison.get().getPlatform().getConfigBooleanFalse( 
+								"storage.file.disable-advanced-saves.debug-keep-temp-files" );
+				
+				try
+				{
+					// Write as a .tmp file:
+					
+					// Add json data to lines, splitting on \n:
+					List<String> lines = Arrays.asList( data.split( "\n" ));
+					
+					
+					// Write to both temp file and the actual file:
+					
+					// Write as an UTF-8 stream:
+					Files.write( tempFile.toPath(), lines, StandardCharsets.UTF_8 );
+					
+					
+					StandardOpenOption sooW = StandardOpenOption.WRITE;
+					StandardOpenOption sooTe = StandardOpenOption.TRUNCATE_EXISTING;
+					
+					Files.write( file.toPath(), lines, StandardCharsets.UTF_8, sooW, sooTe );
+					
+					
+//				Files.write( tempFile.toPath(), data.getBytes() );
+					
+					// If original target exists, then delete it:
+//					if ( file.exists() )
+//					{
+//						file.delete();
+//					}
+//					
+//					tempFile.renameTo( file );
+					
+					
+					if ( !keepTempFiles ) {
+						tempFile.delete();
+					}
+					
+				}
+				catch ( IOException e )
+				{
+					logException( "Failed to create file", file, e );
+				}
 			}
-			catch ( IOException e )
-			{
-				logException( "Failed to create file", file, e );
-			}
+			
 			
 		}
 	}

--- a/prison-core/src/main/java/tech/mcprison/prison/file/FileIO.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/file/FileIO.java
@@ -136,9 +136,12 @@ public abstract class FileIO
 					// Write as an UTF-8 stream:
 					Files.write( tempFile.toPath(), lines, StandardCharsets.UTF_8 );
 					
+					boolean exists = file.exists();
 					
 					StandardOpenOption sooW = StandardOpenOption.WRITE;
-					StandardOpenOption sooTe = StandardOpenOption.TRUNCATE_EXISTING;
+					StandardOpenOption sooTe = exists ?
+									StandardOpenOption.TRUNCATE_EXISTING : 
+									StandardOpenOption.CREATE;
 					
 					Files.write( file.toPath(), lines, StandardCharsets.UTF_8, sooW, sooTe );
 					

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/CommandSender.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/CommandSender.java
@@ -18,6 +18,8 @@
 
 package tech.mcprison.prison.internal;
 
+import java.util.List;
+
 /**
  * Represents any entity that may send commands and receive output.
  *
@@ -89,5 +91,7 @@ public interface CommandSender
 
     
     public boolean isPlayer();
+
+	List<String> getSellAllMultiplierListings();
 
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/CommandSender.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/CommandSender.java
@@ -20,6 +20,8 @@ package tech.mcprison.prison.internal;
 
 import java.util.List;
 
+import tech.mcprison.prison.ranks.data.RankPlayer;
+
 /**
  * Represents any entity that may send commands and receive output.
  *
@@ -114,6 +116,9 @@ public interface CommandSender
 	 * @return Player
 	 */
 	public Player getPlatformPlayer();
+
+	
+	public RankPlayer getRankPlayer();
 
 
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/CommandSender.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/CommandSender.java
@@ -39,18 +39,18 @@ public interface CommandSender
     /**
      * Returns the name of the command sender.
      */
-    String getName();
+    public String getName();
 
     /**
      * Force a commandSender to send a command
      */
-    void dispatchCommand(String command);
+    public void dispatchCommand(String command);
 
     /**
      * Returns true if the command sender can show colors to the viewer.
      * This is not always the case, especially when using command blocks and online consoles.
      */
-    boolean doesSupportColors();
+    public boolean doesSupportColors();
 
     /**
      * Sends a message to the command sender.
@@ -59,7 +59,7 @@ public interface CommandSender
      *
      * @param message The message to send. May include color codes, amp-prefixed.
      */
-    void sendMessage(String message);
+    public void sendMessage(String message);
 
     /**
      * Sends multiple messages to the command sender.
@@ -68,14 +68,23 @@ public interface CommandSender
      * @param messages The array containing each message.
      * @see #sendMessage(String)
      */
-    void sendMessage(String[] messages);
+    public void sendMessage(String[] messages);
 
+    /**
+     * Sends multiple messages to the command sender.
+     * Each message will be shown on its own line.
+     *
+     * @param messages The List<String> containing each message.
+     * @see #sendMessage(String)
+     */
+    public void sendMessage(List<String> messages);
+    
     /**
      * Send a raw JSON message to the sender.
      *
      * @param json The JSON message. Must be in proper format.
      */
-    void sendRaw(String json);
+    public void sendRaw(String json);
     
     
 //    public boolean isOp();
@@ -92,6 +101,19 @@ public interface CommandSender
     
     public boolean isPlayer();
 
-	List<String> getSellAllMultiplierListings();
+	public List<String> getSellAllMultiplierListings();
+	
+	
+	/**
+	 * <p>Returns an instance of a Platform player object, which is is 
+	 * different than just a RankPlayer since it was built with the wrapper of
+	 * SpigotPlayer (when running on spigot).  So this object is actually backed
+	 * by the the actual player object too.
+	 * </p>
+	 * 
+	 * @return Player
+	 */
+	public Player getPlatformPlayer();
+
 
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/ItemStack.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/ItemStack.java
@@ -20,9 +20,7 @@ package tech.mcprison.prison.internal;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -41,14 +39,14 @@ public class ItemStack {
     private int amount;
     private PrisonBlock material;
     private List<String> lore;
-    private Map<Integer, Integer> enchantments;
+//    private Map<Integer, Integer> enchantments;
 
     
     protected ItemStack() {
     	super();
     	
     	this.lore = new ArrayList<>();
-    	this.enchantments = new HashMap<>();
+//    	this.enchantments = new HashMap<>();
     }
     
     public ItemStack(String displayName, int amount, PrisonBlock material, String... lore) {
@@ -56,7 +54,7 @@ public class ItemStack {
         this.amount = amount;
         this.material = material;
         this.lore = new ArrayList<>(Arrays.asList(lore));
-        this.enchantments = new HashMap<>();
+//        this.enchantments = new HashMap<>();
     }
 
     public ItemStack(int amount, PrisonBlock material, String... lore) {
@@ -114,21 +112,21 @@ public class ItemStack {
 		this.lore = lore;
 	}
 
-	public Map<Integer, Integer> getEnchantments() {
-        return enchantments;
-    }
-
-    public void addEnchantment(int enchantment, int level) {
-        enchantments.put(enchantment, level);
-    }
-
-    public boolean hasEnchantments() {
-        return !enchantments.isEmpty();
-    }
-
-    public boolean hasEnchantment(int enchantment) {
-        return enchantments.containsKey(enchantment);
-    }
+//	public Map<Object, Integer> getEnchantments() {
+//        return enchantments;
+//    }
+//
+//    public void addEnchantment(Object enchantment, int level) {
+//        enchantments.put(enchantment, level);
+//    }
+//
+//    public boolean hasEnchantments() {
+//        return !enchantments.isEmpty();
+//    }
+//
+//    public boolean hasEnchantment(int enchantment) {
+//        return enchantments.containsKey(enchantment);
+//    }
 
     @Override public boolean equals(Object o) {
         if (this == o) {
@@ -157,6 +155,8 @@ public class ItemStack {
 
     @Override public String toString() {
         return "ItemStack{" + "displayName='" + displayName + '\'' + ", amount=" + amount
-            + ", material=" + material + ", lore=" + lore + ", enchantments=" + enchantments + '}';
+            + ", material=" + material + ", lore=" + lore +
+            "}";
+            //", enchantments=" + enchantments + '}';
     }
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/Player.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/Player.java
@@ -78,12 +78,12 @@ public interface Player
     /**
      * Adds an {@link ItemStack} to the player's inventory.
      */
-    void give(ItemStack itemStack);
+    public void give(ItemStack itemStack);
 
     /**
      * Returns the player's current {@link Location}.
      */
-    Location getLocation();
+    public Location getLocation();
 
     
     /**
@@ -105,31 +105,31 @@ public interface Player
      *
      * @param location The new {@link Location}.
      */
-    void teleport(Location location);
+    public void teleport(Location location);
 
     /**
      * @return Returns true if the player is online, false otherwise.
      */
-    boolean isOnline();
+    public boolean isOnline();
 
     /**
      * Sets the player's visible scoreboard.
      *
      * @param scoreboard The {@link Scoreboard} to show the player.
      */
-    void setScoreboard(Scoreboard scoreboard);
+    public void setScoreboard(Scoreboard scoreboard);
 
     /**
      * Returns the player's current {@link Gamemode}
      */
-    Gamemode getGamemode();
+    public Gamemode getGamemode();
 
     /**
      * Changes the player's {@link Gamemode} to the specified value
      *
      * @param gamemode the new gamemode
      */
-    void setGamemode(Gamemode gamemode);
+    public void setGamemode(Gamemode gamemode);
 
     /**
      * Returns this player's locale.
@@ -137,10 +137,11 @@ public interface Player
      * @return An {@link Optional} containing the locale of this player, or empty if it couldn't be
      * retrieved.
      */
-    Optional<String> getLocale();
+    public Optional<String> getLocale();
 
 
-    @Override default boolean doesSupportColors() {
+    @Override 
+    public default boolean doesSupportColors() {
         return true;
     }
 
@@ -149,7 +150,7 @@ public interface Player
      * inventory. May not be necessary on all platforms but should be used where ever the player inventory
      * is modified
      */
-    void updateInventory();
+    public void updateInventory();
     
     
 //    /**
@@ -176,5 +177,7 @@ public interface Player
 	public void incrementMinecraftStatsMineBlock( Player player, String blockName, int quantity );
 	
 	public void incrementMinecraftStatsDropCount( Player player, String blockName, int quantity);
+
+//	public RankPlayer getRankPlayer();
 	
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/block/MineTargetPrisonBlock.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/block/MineTargetPrisonBlock.java
@@ -24,6 +24,10 @@ public class MineTargetPrisonBlock
 	private boolean ignoreAllBlockEvents = false;
 	
 	
+	private transient boolean checkAir;
+	private transient boolean checkSame;
+	
+	
 	public MineTargetPrisonBlock( 
 				PrisonBlockStatusData prisonBlock, 
 				World world, 
@@ -189,6 +193,20 @@ public class MineTargetPrisonBlock
 	}
 	public void setIgnoreAllBlockEvents( boolean ignoreAllBlockEvents ) {
 		this.ignoreAllBlockEvents = ignoreAllBlockEvents;
+	}
+
+	public boolean isCheckAir() {
+		return checkAir;
+	}
+	public void setCheckAir(boolean checkAir) {
+		this.checkAir = checkAir;
+	}
+
+	public boolean isCheckSame() {
+		return checkSame;
+	}
+	public void setCheckSame(boolean checkSame) {
+		this.checkSame = checkSame;
 	}
 
 	@Override 

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/block/MineTargetPrisonBlock.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/block/MineTargetPrisonBlock.java
@@ -46,6 +46,19 @@ public class MineTargetPrisonBlock
 		this.isCorner = isCorner;
 	}
 
+	public MineTargetPrisonBlock( 
+			PrisonBlockStatusData prisonBlock, 
+			Location targetLocation ) {
+		this( prisonBlock, targetLocation.getWorld(),
+				targetLocation.getBlockX(), 
+				targetLocation.getBlockY(), 
+				targetLocation.getBlockZ(),
+				targetLocation.isEdge(),
+				targetLocation.isCorner()
+				);
+
+	}
+	
 	@Override
 	public String toString() {
 		return "MineTargetPrisonBlock: key= " + getBlockKey().toString() + 

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlock.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlock.java
@@ -45,6 +45,7 @@ public class PrisonBlock
 	
 	private Double salePrice = null;
 	private Double purchasePrice = null;
+	private boolean loreAllowed = false;
 	
 	
 	static {
@@ -524,6 +525,13 @@ public class PrisonBlock
 		ItemStack results = Prison.get().getPlatform().getItemStack( this, blockQuantity );
 		
 		return results;
+	}
+	
+	public boolean isLoreAllowed() {
+		return loreAllowed;
+	}
+	public void setLoreAllowed(boolean loreAllowed) {
+		this.loreAllowed = loreAllowed;
 	}
 	
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlockStatusData.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlockStatusData.java
@@ -45,6 +45,12 @@ public abstract class PrisonBlockStatusData {
 	private transient boolean includeInLayerCalculations;
 	
 	
+	private transient String altAlias;
+	private transient String altColorCode;
+	private transient int altCountVirtual;
+	private transient int altCountPhysical;
+	
+	
 	public PrisonBlockStatusData( 
 			PrisonBlockType blockType, String blockName, String displayName,
 			double chance, long blockCountTotal ) {
@@ -617,6 +623,70 @@ public abstract class PrisonBlockStatusData {
 		}
 		
 		return position;
+	}
+
+	public void setAltValues( int i ) {
+		
+		String codes = "abcdefghijklmnopqrstuvwxyz";
+		String colors = "12345789abcde";
+	
+		int codePos = i % codes.length();
+		int codeFactor = i / codes.length();
+		
+		String code = codePos == codes.length() ?
+				codes.substring( codePos ) :
+				codes.substring( codePos, codePos + 1 );
+		
+		String alias = code + 
+						(codeFactor == 0 ?
+								"" :
+								codeFactor);
+		setAltAlias( alias );
+		
+		int colorPos = i % colors.length();
+		String color = colorPos == colors.length() ?
+				colors.substring( colorPos ) :
+				colors.substring( colorPos, colorPos + 1 );
+		setAltColorCode( "&" + color );
+		
+		setAltCountVirtual( 0 );
+		setAltCountPhysical( 0 );
+		
+	}
+	
+	public void resetAltValues() {
+		
+		setAltCountVirtual( 0 );
+		setAltCountPhysical( 0 );
+		
+	}
+	
+	public String getAltAlias() {
+		return altAlias;
+	}
+	public void setAltAlias(String altAlias) {
+		this.altAlias = altAlias;
+	}
+
+	public String getAltColorCode() {
+		return altColorCode;
+	}
+	public void setAltColorCode(String altColorCode) {
+		this.altColorCode = altColorCode;
+	}
+
+	public int getAltCountVirtual() {
+		return altCountVirtual;
+	}
+	public void setAltCountVirtual(int altCountVirtual) {
+		this.altCountVirtual = altCountVirtual;
+	}
+
+	public int getAltCountPhysical() {
+		return altCountPhysical;
+	}
+	public void setAltCountPhysical(int altCountPhysical) {
+		this.altCountPhysical = altCountPhysical;
 	}
 
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlockStatusData.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/block/PrisonBlockStatusData.java
@@ -42,7 +42,7 @@ public abstract class PrisonBlockStatusData {
 	
 	private boolean gravity = false;
 	
-	private transient boolean includeInLayerCalculations;
+//	private transient boolean includeInLayerCalculations;
 	
 	
 	private transient String altAlias;
@@ -90,7 +90,7 @@ public abstract class PrisonBlockStatusData {
 		
 		this.gravity = checkGravityAffects( blockName );
 		
-		this.includeInLayerCalculations = true;
+//		this.includeInLayerCalculations = true;
 	}
 
 	
@@ -556,12 +556,12 @@ public abstract class PrisonBlockStatusData {
 
 
 	
-	public boolean isIncludeInLayerCalculations() {
-		return includeInLayerCalculations;
-	}
-	public void setIncludeInLayerCalculations(boolean includeInLayerCalculations) {
-		this.includeInLayerCalculations = includeInLayerCalculations;
-	}
+//	public boolean isIncludeInLayerCalculations() {
+//		return includeInLayerCalculations;
+//	}
+//	public void setIncludeInLayerCalculations(boolean includeInLayerCalculations) {
+//		this.includeInLayerCalculations = includeInLayerCalculations;
+//	}
 
 
 	/**

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/platform/Platform.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/platform/Platform.java
@@ -386,6 +386,18 @@ public interface Platform {
 	public String dumpEventListenersPlayerInteractEvents();
 
 	
+	
+
+	public String dumpEventListenersBlockPlaceEvents();
+
+
+	public String dumpEventListenersPlayerDropItemEvents();
+
+
+	public String dumpEventListenersPlayerPickupItemEvents();
+	
+	
+	
 	public void testPlayerUtil( UUID uuid );
 	
 

--- a/prison-core/src/main/java/tech/mcprison/prison/internal/platform/Platform.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/internal/platform/Platform.java
@@ -359,6 +359,9 @@ public interface Platform {
 					boolean forceLinersBottom, boolean forceLinersWalls );
 	
 	
+	public String autoCreateMineLinerAssignment(ModuleElement eMine, 
+					boolean forceLinersBottom, boolean forceLinersWalls);
+	
 	public void autoCreateConfigureMines();
 	
 	
@@ -476,5 +479,9 @@ public interface Platform {
 
 
 	public String getRankByFileName(String name);
+
+
+	public Map<String, Object> loadYaml(File file);
+
 
 }

--- a/prison-core/src/main/java/tech/mcprison/prison/localization/Localizable.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/localization/Localizable.java
@@ -370,7 +370,17 @@ public class Localizable {
     	String message = localizeFor(sender);
     	if ( message != null && !message.isEmpty() ) {
     		
-    		Output.get().sendMessage(sender, message, level);
+    		try {
+				Output.get().sendMessage(sender, message, level);
+			} 
+    		catch (Exception e) {
+				Output.get().logRaw( 
+						"Tried to send a formatted mmessage to a player but it ended in "
+						+ "failure. Was the original message edited and an extra parameter added? "
+						+ "raw message: [" +
+							message	
+						+ "]");
+			}
     	}
     }
 

--- a/prison-core/src/main/java/tech/mcprison/prison/localization/Localizable.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/localization/Localizable.java
@@ -42,6 +42,7 @@ import tech.mcprison.prison.internal.Player;
 import tech.mcprison.prison.internal.World;
 import tech.mcprison.prison.output.LogLevel;
 import tech.mcprison.prison.output.Output;
+import tech.mcprison.prison.placeholders.PlaceholderStringCoverter;
 import tech.mcprison.prison.ranks.data.PlayerRank;
 import tech.mcprison.prison.ranks.data.Rank;
 import tech.mcprison.prison.ranks.data.RankPlayer;
@@ -405,17 +406,20 @@ public class Localizable {
      * @param sender The {@link CommandSender} to send this {@link Localizable} to
      */
     public void sendTo(CommandSender sender ) {
-    	CommandSender playerStats = null;
-    	sendTo( sender, playerStats );
+    	PlaceholderStringCoverter placeholderConverter = null;
+    	sendTo( sender, placeholderConverter );
     }
-    public void sendTo(CommandSender sender, CommandSender playerStats ) {
+    public void sendTo(CommandSender sender, PlaceholderStringCoverter placeholderConverter ) {
     	
     	String message = localize();
     	if ( message != null && !message.isEmpty() ) {
 
-    		message = applySecondaryPlaceholders( 
-    				(playerStats != null ? playerStats : sender ),
-    				message );
+    		if ( placeholderConverter != null ) {
+    			message = placeholderConverter.convertStringPlaceholders(message);
+    		}
+//    		message = applySecondaryPlaceholders( 
+//    				(playerStats != null ? playerStats : sender ),
+//    				message );
     		
     		sendTo(sender, LogLevel.PLAIN);
     	}
@@ -428,16 +432,16 @@ public class Localizable {
      * @since 1.0
      */
     public void broadcast() {
-    	CommandSender playerStats = null;
-    	broadcast( playerStats );
+    	PlaceholderStringCoverter placeholderConverter = null;
+    	broadcast( placeholderConverter );
     }
-    public void broadcast( CommandSender playerStats ) {
+    public void broadcast( PlaceholderStringCoverter placeholderConverter ) {
     	
     	String message = localize();
     	if ( message != null && !message.isEmpty() ) {
     		
     		for (Player player : Prison.get().getPlatform().getOnlinePlayers()) {
-    			sendTo(player, playerStats);
+    			sendTo(player, placeholderConverter);
     		}
     		Output.get().logInfo( message );
     	}

--- a/prison-core/src/main/java/tech/mcprison/prison/output/Output.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/output/Output.java
@@ -383,6 +383,17 @@ public class Output
         }
     }
     
+    /**
+     * <p>This will log a message to the console without any conversion of color codes or
+     * anything else.  Expect issues with color formatting.
+     * </p>
+     * 
+     * @param message
+     */
+    public void logRaw( String message ) {
+    	Prison.get().getPlatform().logPlain(message);
+    }
+    
     public void logDebug(String message, Object... args) {
     	logDebug( message, null, args );
     }

--- a/prison-core/src/main/java/tech/mcprison/prison/output/Output.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/output/Output.java
@@ -142,7 +142,13 @@ public class Output
 
     public static Output get() {
         if (instance == null) {
-            new Output();
+        	synchronized ( Output.class ) {
+        		if (instance == null) {
+        			
+        			new Output();
+        			
+        		}
+			}
         }
         return instance;
     }

--- a/prison-core/src/main/java/tech/mcprison/prison/output/Output.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/output/Output.java
@@ -81,8 +81,9 @@ public class Output
     	
     	targetBlockMismatch,
     	
-    	rankup
+    	rankup,
 //    	support
+    	blockConstraints
     	;
     	
     	public static DebugTarget fromString( String target ) {

--- a/prison-core/src/main/java/tech/mcprison/prison/placeholders/PlaceholderStringCoverter.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/placeholders/PlaceholderStringCoverter.java
@@ -1,0 +1,14 @@
+package tech.mcprison.prison.placeholders;
+
+public interface PlaceholderStringCoverter {
+	
+	/**
+	 * <p>This returns a String list of all available placeholders that can be used.
+	 * </p>
+	 * @return
+	 */
+	public String getStringPlaceholders();
+	
+	public String convertStringPlaceholders( String source );
+
+}

--- a/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
@@ -50,6 +50,7 @@ import tech.mcprison.prison.util.Text;
  * @author Faizaan A. Datoo
  */
 public class RankPlayer 
+		extends RankPlayerMessages
 			implements Player {
 
 	public static final long DELAY_THREE_SECONDS = 20 * 3; // 3 seconds in ticks
@@ -1690,16 +1691,19 @@ public class RankPlayer
 //	}
 	
 	public static String printRankScoreLine1Header() {
-		String header = String.format(
-				"Rank  %-16s %-9s  %-6s %-9s %-9s %-9s",
-					"Player",
-					"Prestiges",
-					"Rank",
-					"Balance",
-					"Rank-Score",
-					"Penalty"
-						
-				);
+		
+		String header = coreTopNLine1HeaderMsg();
+		
+//		String header = String.format(
+//				"Rank  %-16s %-9s  %-6s %-9s %-9s %-9s",
+//					"Player",
+//					"Prestiges",
+//					"Rank",
+//					"Balance",
+//					"Rank-Score",
+//					"Penalty"
+//						
+//				);
 		return header;
 	}
 	
@@ -1707,28 +1711,55 @@ public class RankPlayer
 		
 		DecimalFormat dFmt = Prison.get().getDecimalFormat("#,##0.00");
 		
-		PlayerRank prestRank = getPlayerRankPrestiges();
+		PlayerRank prestigeRank = getPlayerRankPrestiges();
 		PlayerRank defRank = getPlayerRankDefault();
 		
-		String prestRankTag = prestRank == null ? "---" : prestRank.getRank().getTag();
+		String prestigeRankName = prestigeRank == null ? "" : prestigeRank.getRank().getName();
+		String defaultRankName = defRank == null ? "" : defRank.getRank().getName();
+		
+		String prestRankTag = prestigeRank == null ? "---" : prestigeRank.getRank().getTag();
 		String defRankTag = defRank == null ? "---" : defRank.getRank().getTag();
 		
 		String prestRankTagNc = Text.stripColor(prestRankTag);
 		String defRankTagNc = Text.stripColor(defRankTag);
 		
-		String balanceStr = PlaceholdersUtil.formattedKmbtSISize( getRankScoreBalance(), dFmt, " " );
+		String balanceFmtStr = dFmt.format( getRankScoreBalance()  );
+		String balanceKmbtStr = PlaceholdersUtil.formattedKmbtSISize( getRankScoreBalance(), dFmt, " " );
+		String balanceMetricStr = PlaceholdersUtil.formattedMetricSISize( getRankScoreBalance(), dFmt, " " );
+		
+		String rankPositionStr = Integer.toString(rankPostion);
+		String rankScoreStr = rankPostion > 0 ? Integer.toString(rankPostion) : "";
 		String sPenaltyStr = PlaceholdersUtil.formattedKmbtSISize( getRankScorePenalty(), dFmt, " " );
 		
-		String message = String.format(
-				" %-3s  %-18s %-7s %-7s %9s %9s %9s",
-					(rankPostion > 0 ? Integer.toString(rankPostion) : ""),
-					getName(),
-					prestRankTagNc,
-					defRankTagNc,
-					balanceStr,
-					dFmt.format( getRankScore() ),
-					sPenaltyStr
+		String playerName = getName();
+		
+		String message = coreTopNLine1DetailMsg( 
+				
+				playerName,
+				rankPositionStr,
+				rankScoreStr,
+				sPenaltyStr,
+				prestigeRankName, 
+				defaultRankName, 
+				prestRankTag,
+				defRankTag,
+				prestRankTagNc,
+				defRankTagNc,
+				balanceFmtStr,
+				balanceKmbtStr,
+				balanceMetricStr
+				
 				);
+//		String message = String.format(
+//				" %-3s  %-18s %-7s %-7s %9s %9s %9s",
+//					rankScoreStr,
+//					getName(),
+//					prestRankTagNc,
+//					defRankTagNc,
+//					balanceKmbtStr,
+//					dFmt.format( getRankScore() ),
+//					sPenaltyStr
+//				);
 		
 		message = message
 					.replace(prestRankTagNc, prestRankTag + "&r")
@@ -1738,46 +1769,82 @@ public class RankPlayer
 	}
 	
 	public static String printRankScoreLine2Header() {
-		String header = String.format(
-				"Rank %s %s %-15s %9s",
-				"Ranks",
-				"Rank-Score",
-				"Player",
-				"Balance"
-				
-				);
+		
+		String header = coreTopNLine2HeaderMsg();
+//		String header = String.format(
+//				"Rank %s %s %-15s %9s",
+//				"Ranks",
+//				"Rank-Score",
+//				"Player",
+//				"Balance"
+//				
+//				);
 		return header;
 	}
 	
 	public String printRankScoreLine2( int rankPostion ) {
-		
+
 		DecimalFormat dFmt = Prison.get().getDecimalFormat("#,##0.00");
 		
-		PlayerRank prestRank = getPlayerRankPrestiges();
+		PlayerRank prestigeRank = getPlayerRankPrestiges();
 		PlayerRank defRank = getPlayerRankDefault();
 		
-		String prestRankTag = prestRank == null ? "---" : prestRank.getRank().getTag();
+		String prestigeRankName = prestigeRank == null ? "" : prestigeRank.getRank().getName();
+		String defaultRankName = defRank == null ? "" : defRank.getRank().getName();
+		
+		String prestRankTag = prestigeRank == null ? "---" : prestigeRank.getRank().getTag();
 		String defRankTag = defRank == null ? "---" : defRank.getRank().getTag();
 		
 		String prestRankTagNc = Text.stripColor(prestRankTag);
 		String defRankTagNc = Text.stripColor(defRankTag);
 		
-		String balanceStr = PlaceholdersUtil.formattedKmbtSISize( getRankScoreBalance(), dFmt, " " );
-//		String sPenaltyStr = PlaceholdersUtil.formattedKmbtSISize( getRankScorePenalty(), dFmt, " " );
+		String balanceFmtStr = dFmt.format( getRankScoreBalance()  );
+		String balanceKmbtStr = PlaceholdersUtil.formattedKmbtSISize( getRankScoreBalance(), dFmt, " " );
+		String balanceMetricStr = PlaceholdersUtil.formattedMetricSISize( getRankScoreBalance(), dFmt, " " );
 		
-		String ranks = prestRankTagNc + defRankTagNc;
-		String message = String.format(
-				" %-3s %-9s %6s %-17s %9s",
-				(rankPostion > 0 ? Integer.toString(rankPostion) : ""),
-				ranks,
-				dFmt.format( getRankScore() ),
-				getName(),
-				balanceStr
-				);
+		String rankPositionStr = Integer.toString(rankPostion);
+		String rankScoreStr = rankPostion > 0 ? Integer.toString(rankPostion) : "";
+		String sPenaltyStr = PlaceholdersUtil.formattedKmbtSISize( getRankScorePenalty(), dFmt, " " );
 		
-		message = message
-				.replace(prestRankTagNc, prestRankTag + "&r")
-				.replace(defRankTagNc, defRankTag + "&r");
+		String playerName = getName();
+		
+//		DecimalFormat dFmt = Prison.get().getDecimalFormat("#,##0.00");
+//		
+//		PlayerRank prestRank = getPlayerRankPrestiges();
+//		PlayerRank defRank = getPlayerRankDefault();
+//		
+//		String prestRankTag = prestRank == null ? "---" : prestRank.getRank().getTag();
+//		String defRankTag = defRank == null ? "---" : defRank.getRank().getTag();
+//		
+//		String prestRankTagNc = Text.stripColor(prestRankTag);
+//		String defRankTagNc = Text.stripColor(defRankTag);
+//		
+//		String balanceKmbtStr = PlaceholdersUtil.formattedKmbtSISize( getRankScoreBalance(), dFmt, " " );
+////		String sPenaltyStr = PlaceholdersUtil.formattedKmbtSISize( getRankScorePenalty(), dFmt, " " );
+//		
+//		String ranks = prestRankTagNc + defRankTagNc;
+		
+		String message = coreTopNLine2DetailMsg( 
+				playerName,
+				rankPositionStr,
+				rankScoreStr, sPenaltyStr,
+				prestigeRankName, defaultRankName, 
+				prestRankTag, defRankTag, 
+				prestRankTagNc, defRankTagNc, 
+				balanceFmtStr,  balanceKmbtStr, balanceMetricStr );
+		
+//		String message = String.format(
+//				" %-3s %-9s %6s %-17s %9s",
+//				(rankPostion > 0 ? Integer.toString(rankPostion) : ""),
+//				ranks,
+//				dFmt.format( getRankScore() ),
+//				getName(),
+//				balanceKmbtStr
+//				);
+//		
+//		message = message
+//				.replace(prestRankTagNc, prestRankTag + "&r")
+//				.replace(defRankTagNc, defRankTag + "&r");
 		
 		return message;
 	}

--- a/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
@@ -1826,6 +1826,14 @@ public class RankPlayer
 		this.rankScorePenalty = rankScorePenalty;
 	}
 
+	@Override
+	public List<String> getSellAllMultiplierListings() {
+		
+		Player player = Prison.get().getPlatform().getPlayer(getUUID()).orElse(null);
+		
+		return player == null ? new ArrayList<>() : player.getSellAllMultiplierListings();
+	}
+
 //	public long getRankScoreCooldown() {
 //		return rankScoreCooldown;
 //	}

--- a/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
@@ -908,6 +908,11 @@ public class RankPlayer
 	}
 	
 	@Override
+	public void sendMessage( List<String> messages ) {
+		Output.get().logError( "RankPlayer.sendMessage: Cannot send messages to offline players." );
+	}
+	
+	@Override
 	public void sendRaw( String json ) {
 		Output.get().logError( "RankPlayer.sendRaw: Cannot send messages to offline players." );
 	}
@@ -969,7 +974,7 @@ public class RankPlayer
 
 	@Override
 	public boolean isOp() {
-		Player player = getPlayer();
+		Player player = getPlatformPlayer();
 		return (player != null ? player.isOp() : false );
 	}
 	
@@ -982,14 +987,14 @@ public class RankPlayer
 	 */
     @Override 
     public boolean isPlayer() {
-    	Player player = getPlayer();
+    	Player player = getPlatformPlayer();
     	return (player != null ? player.isPlayer() : false );
     }
 	
 
 	@Override
 	public void updateInventory() {
-		Player player = getPlayer();
+		Player player = getPlatformPlayer();
 		if ( player != null ) {
 			
 			player.updateInventory();
@@ -1000,7 +1005,7 @@ public class RankPlayer
 	public Inventory getInventory() {
 		Inventory results = null;
 		
-		Player player = getPlayer();
+		Player player = getPlatformPlayer();
 		if ( player != null ) {
 			
 			results = player.getInventory();
@@ -1014,15 +1019,9 @@ public class RankPlayer
 //		
 //	}
 	
-	/**
-	 * <p>Player is not cached in this class, so if using it in a function 
-	 * make a local variable to save it instead of calling this function multiple
-	 * times since it is a high impact lookup.
-	 * </p>
-	 * 
-	 * @return
-	 */
-	private Player getPlayer() {
+
+	@Override
+	public Player getPlatformPlayer() {
 		Player player = null;
 		
 		Optional<Player> oPlayer = Prison.get().getPlatform().getPlayer( uid );
@@ -1030,12 +1029,14 @@ public class RankPlayer
 		if ( oPlayer.isPresent() ) {
 			player = oPlayer.get();
 		}
+		
 		return player;
 	}
 	
+	
 	@Override
 	public void recalculatePermissions() {
-		Player player = getPlayer();
+		Player player = getPlatformPlayer();
 		if ( player != null ) {
 			player.recalculatePermissions();
 		}
@@ -1043,13 +1044,13 @@ public class RankPlayer
 	
     @Override
     public List<String> getPermissions() {
-    	Player player = getPlayer();
+    	Player player = getPlatformPlayer();
     	return (player == null ? new ArrayList<>() : player.getPermissions() );
     }
     
     @Override
     public List<String> getPermissions( String prefix ) {
-    	Player player = getPlayer();
+    	Player player = getPlatformPlayer();
     	return (player == null ? new ArrayList<>() : player.getPermissions( prefix ) );
     }
     
@@ -1072,7 +1073,7 @@ public class RankPlayer
     public double getSellAllMultiplier() {
     	double results = 1.0;
     	
-    	Player player = getPlayer();
+    	Player player = getPlatformPlayer();
     	if ( player != null ) {
     		results = player.getSellAllMultiplier();
     	}

--- a/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
@@ -1035,6 +1035,11 @@ public class RankPlayer
 	
 	
 	@Override
+	public RankPlayer getRankPlayer() {
+		return this;
+	}
+	
+	@Override
 	public void recalculatePermissions() {
 		Player player = getPlatformPlayer();
 		if ( player != null ) {

--- a/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
@@ -39,6 +39,7 @@ import tech.mcprison.prison.internal.block.Block;
 import tech.mcprison.prison.internal.inventory.Inventory;
 import tech.mcprison.prison.internal.scoreboard.Scoreboard;
 import tech.mcprison.prison.output.Output;
+import tech.mcprison.prison.placeholders.PlaceholderStringCoverter;
 import tech.mcprison.prison.placeholders.PlaceholdersUtil;
 import tech.mcprison.prison.util.Gamemode;
 import tech.mcprison.prison.util.Location;
@@ -51,7 +52,7 @@ import tech.mcprison.prison.util.Text;
  */
 public class RankPlayer 
 		extends RankPlayerMessages
-			implements Player {
+			implements Player, PlaceholderStringCoverter {
 
 	public static final long DELAY_THREE_SECONDS = 20 * 3; // 3 seconds in ticks
 	
@@ -1905,6 +1906,112 @@ public class RankPlayer
 		Player player = Prison.get().getPlatform().getPlayer(getUUID()).orElse(null);
 		
 		return player == null ? new ArrayList<>() : player.getSellAllMultiplierListings();
+	}
+
+
+	@Override
+	public String getStringPlaceholders() {
+		String results = 
+				"{player} {rank_default} {rank_tag_default} {rank_next_default} {rank_next_tag_default} " +
+				"{rank_prestiges} {rank_tag_prestiges} {rank_next_prestiges} {rank_next_tag_prestiges}";
+		
+		return results;
+	}
+	
+    /**
+     * <p>This function will provide support for secondary placeholders for all player related placeholders.
+     * These secondary placeholders are in addition to the preexisting positional placeholders
+     * that are hard coded for the specific parameters. 
+     * </p>
+     * 
+     * <p>These secondary placeholders can be inserted anywhere in the message.
+     * </p>
+     * 
+     * <ul>
+     * 	<li>{player}</li>
+     * 	<li>{rank_default}</li>
+     * 	<li>{rank_tag_default}</li>
+     * 	<li>{rank_next_default}</li>
+     * 	<li>{rank_next_tag_default}</li>
+     * 	<li>{rank_prestiges}</li>
+     * 	<li>{rank_tag_prestiges}</li>
+     * 	<li>{rank_next_prestiges}</li>
+     * 	<li>{rank_next_tag_prestiges}</li>
+     * 
+     *  <li>{player} {rank_default} {rank_tag_default} {rank_next_default} {rank_next_tag_default}</li>
+     * 	<li>{rank_prestiges} {rank_tag_prestiges} {rank_next_prestiges} {rank_next_tag_prestiges}</li>
+     * </ul>
+     * 
+     * @param rankPlayer
+     * @param results
+     * @return
+     */
+	@Override
+	public String convertStringPlaceholders(String results) {
+
+		RankPlayer rankPlayer = this;
+		
+		if ( rankPlayer != null ) {
+			
+			results = applySecondaryPlaceholdersCheck( "{player}", rankPlayer.getName(), results );
+			
+			if ( rankPlayer.getPlayerRankDefault() != null ) {
+				PlayerRank rankP = rankPlayer.getPlayerRankDefault();
+				Rank rank = rankP == null ? null : rankP.getRank();
+				Rank rankNext = rank == null ? null : rank.getRankNext();
+				
+				results = applySecondaryPlaceholdersCheck( "{rank_default}", 
+						rank == null ? "" : rank.getName(), results );
+				results = applySecondaryPlaceholdersCheck( "{rank_tag_default}", 
+						rank == null ? "" : rank.getTag(), results );
+				
+				results = applySecondaryPlaceholdersCheck( "{rank_next_default}", 
+						rankNext == null ? "" : rankNext.getName(), results );
+				results = applySecondaryPlaceholdersCheck( "{rank_next_tag_default}", 
+						rankNext == null ? "" : rankNext.getTag(), results );
+			}
+			
+			if ( rankPlayer.getPlayerRankPrestiges() != null ) {
+				
+				PlayerRank rankP = rankPlayer.getPlayerRankPrestiges();
+				Rank rank = rankP == null ? null : rankP.getRank();
+				Rank rankNext = rank == null ? null : rank.getRankNext();
+				
+				results = applySecondaryPlaceholdersCheck( "{rank_prestiges}", 
+						rank == null ? "" : rank.getName(), results );
+				results = applySecondaryPlaceholdersCheck( "{rank_tag_prestiges}", 
+						rank == null ? "" : rank.getTag(), results );
+				
+				results = applySecondaryPlaceholdersCheck( "{rank_next_prestiges}", 
+						rankNext == null ? "" : rankNext.getName(), results );
+				results = applySecondaryPlaceholdersCheck( "{rank_next_tag_prestiges}", 
+						rankNext == null ? "" : rankNext.getTag(), results );
+			}
+			
+		}
+		
+		return results;
+	}
+	
+
+	/**
+	 * <p>Ths function will perform individual replacements of the given placeholders, but
+	 * if the placeholder does not exist, then it will not change anything with the results
+	 * and it will be just passed through.
+	 * </p>
+	 * 
+	 * @param placeholder
+	 * @param value
+	 * @param results
+	 * @return
+	 */
+	private String applySecondaryPlaceholdersCheck( String placeholder, String value, String results) {
+
+		if ( results.contains( placeholder ) && value != null ) {
+			results = results.replace( placeholder, value );
+		}
+		
+		return results;
 	}
 
 //	public long getRankScoreCooldown() {

--- a/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayerMessages.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayerMessages.java
@@ -1,0 +1,248 @@
+package tech.mcprison.prison.ranks.data;
+
+import tech.mcprison.prison.Prison;
+
+public class RankPlayerMessages {
+
+	
+	protected String coreOutputErrorIncorrectNumberOfParametersMsg ( 
+			String levelName, String errorMessage, 
+			String originalMessage, String arguments ) {
+		return Prison.get().getLocaleManager()
+				.getLocalizable( "core_output__error_incorrect_number_of_parameters" )
+				.withReplacements( levelName, errorMessage, 
+							originalMessage, arguments )
+				.localize();
+	}
+	
+	
+	protected static String coreTopNLine1HeaderMsg() {
+		String header = Prison.get().getLocaleManager()
+				.getLocalizable( "core_ranks_topn__player_line_1_header_format" )
+				.localize();
+		header = header.replace( "[", "%" ).replace( "]", "s" );
+		
+		String[] values = coreTopNLine1HeaderValuesMsg();
+		
+		String results = String.format(
+				header,
+				(Object[]) values
+				);
+		return results;
+	}
+	
+	private static String[] coreTopNLine1HeaderValuesMsg () {
+		String[] results = null;
+		String values = Prison.get().getLocaleManager()
+				.getLocalizable( "core_ranks_topn__player_line_1_header_values" )
+				.localize();
+		results = values.split(", ");
+		
+		return results;
+	}
+	
+	
+	
+	protected static String coreTopNLine2HeaderMsg() {
+		String header = Prison.get().getLocaleManager()
+				.getLocalizable( "core_ranks_topn__player_line_2_header_format" )
+				.localize();
+		header = header.replace( "[", "%" ).replace( "]", "s" );
+		
+		String[] values = coreTopNLine2HeaderValuesMsg();
+		
+		String results = String.format(
+				header,
+				(Object[]) values
+				);
+		return results;
+	}
+	
+	private static String[] coreTopNLine2HeaderValuesMsg () {
+		String[] results = null;
+		String values = Prison.get().getLocaleManager()
+				.getLocalizable( "core_ranks_topn__player_line_2_header_values" )
+				.localize();
+		results = values.split(", ");
+		
+		return results;
+	}
+	
+	
+	protected static String coreTopNLine1DetailMsg(
+			String playerName,
+			String rankPositionStr,
+			String rankScoreStr, String sPenaltyStr,
+			String prestigeRankName, String defaultRankName, 
+			String prestRankTag, String defRankTag, 
+			String prestRankTagNc, String defRankTagNc, 
+			String balanceFmtStr, String balanceKmbtStr, String balanceMetricStr) {
+		
+		String detail = Prison.get().getLocaleManager()
+				.getLocalizable( "core_ranks_topn__player_line_1_detail_format" )
+				.localize();
+		detail = detail.replace( "[", "%" ).replace( "]", "s" );
+		
+		String[] values = coreTopNLine1DetailValuesMsg(
+				playerName,
+				rankPositionStr,
+				rankScoreStr,
+				sPenaltyStr,
+				prestigeRankName, 
+				defaultRankName, 
+				prestRankTag,
+				defRankTag,
+				prestRankTagNc,
+				defRankTagNc,
+				balanceFmtStr,
+				balanceKmbtStr,
+				balanceMetricStr
+				);
+		
+		String results = String.format(
+				detail,
+				(Object[]) values
+				);
+		return results;
+	}
+	
+	private static String[] coreTopNLine1DetailValuesMsg(
+			String playerName,
+			String rankPositionStr,
+			String rankScoreStr, String sPenaltyStr,
+			String prestigeRankName, String defaultRankName, 
+			String prestRankTag, String defRankTag, 
+			String prestRankTagNc, String defRankTagNc, 
+			String balanceFmtStr, String balanceKmbtStr, String balanceMetricStr
+			) {
+		
+		String[] results = null;
+		
+		String values = Prison.get().getLocaleManager()
+				.getLocalizable( "core_ranks_topn__player_line_1_detail_values" )
+				.localize();
+		
+		String[] tmp = values.split(",");
+		results = new String[tmp.length];
+		
+		for ( int i = 0; i < tmp.length; i++ ) {
+			String value = tmp[i];
+			
+			results[i] = value
+					.replace( "{playerName}", playerName )
+					.replace( "{rankPosition}", rankPositionStr )
+					.replace( "{rankScore}", rankScoreStr )
+					.replace( "{rankScorePenalty}", sPenaltyStr )
+					
+					.replace( "{prestigeRank}", prestigeRankName )
+					.replace( "{defaultRank}", defaultRankName )
+					.replace( "{prestigeDefaultRank}", prestigeRankName + defaultRankName )
+					
+					.replace( "{prestigeRankTag}", prestRankTag + "&r" )
+					.replace( "{defaultRankTag}", defRankTag + "&r" )
+					.replace( "{prestigeDefaultRankTag}", prestRankTag + defRankTag + "&r" )
+					
+					.replace( "{prestigeRankTagNoColor}", prestRankTagNc )
+					.replace( "{defaultRankTagNoColor}", defRankTagNc )
+					.replace( "{prestigeDefaultRankTagNoColor}", prestRankTagNc + defRankTagNc )
+					
+					.replace( "{balanceFmt}", balanceFmtStr )
+					.replace( "{balanceKmbt}", balanceKmbtStr )
+					.replace( "{balanceMetric}", balanceMetricStr )
+					.trim();
+			
+		}
+		
+		return results;
+	}
+	
+	protected static String coreTopNLine2DetailMsg(
+			String playerName,
+			String rankPositionStr,
+			String rankScoreStr, String sPenaltyStr,
+			String prestigeRankName, String defaultRankName, 
+			String prestRankTag, String defRankTag, 
+			String prestRankTagNc, String defRankTagNc, 
+			String balanceFmtStr, String balanceKmbtStr, String balanceMetricStr) {
+		
+		String detail = Prison.get().getLocaleManager()
+				.getLocalizable( "core_ranks_topn__player_line_2_detail_format" )
+				.localize();
+		detail = detail.replace( "[", "%" ).replace( "]", "s" );
+		
+		String[] values = coreTopNLine2DetailValuesMsg(
+				playerName,
+				rankPositionStr,
+				rankScoreStr,
+				sPenaltyStr,
+				prestigeRankName, 
+				defaultRankName, 
+				prestRankTag,
+				defRankTag,
+				prestRankTagNc,
+				defRankTagNc,
+				balanceFmtStr,
+				balanceKmbtStr,
+				balanceMetricStr
+				);
+		
+		String results = String.format(
+				detail,
+				(Object[]) values
+				);
+		return results;
+	}
+	
+	private static String[] coreTopNLine2DetailValuesMsg(
+			String playerName,
+			String rankPositionStr,
+			String rankScoreStr, String sPenaltyStr,
+			String prestigeRankName, String defaultRankName, 
+			String prestRankTag, String defRankTag, 
+			String prestRankTagNc, String defRankTagNc, 
+			String balanceFmtStr, String balanceKmbtStr, String balanceMetricStr
+			) {
+		
+		String[] results = null;
+		
+		String values = Prison.get().getLocaleManager()
+				.getLocalizable( "core_ranks_topn__player_line_2_detail_values" )
+				.localize();
+		
+		String[] tmp = values.split(",");
+		results = new String[tmp.length];
+		
+		for ( int i = 0; i < tmp.length; i++ ) {
+			String value = tmp[i];
+			
+			
+			results[i] = value
+				.replace( "{playerName}", playerName )
+				.replace( "{rankPosition}", rankPositionStr )
+				.replace( "{rankScore}", rankScoreStr )
+				.replace( "{rankScorePenalty}", sPenaltyStr )
+				
+				.replace( "{prestigeRank}", prestigeRankName )
+				.replace( "{defaultRank}", defaultRankName )
+				.replace( "{prestigeDefaultRank}", prestigeRankName + defaultRankName )
+				
+				.replace( "{prestigeRankTag}", prestRankTag + "&r" )
+				.replace( "{defaultRankTag}", defRankTag + "&r" )
+				.replace( "{prestigeDefaultRankTag}", prestRankTag + defRankTag + "&r" )
+				
+				.replace( "{prestigeRankTagNoColor}", prestRankTagNc )
+				.replace( "{defaultRankTagNoColor}", defRankTagNc )
+				.replace( "{prestigeDefaultRankTagNoColor}", prestRankTagNc + defRankTagNc )
+				
+				.replace( "{balanceFmt}", balanceFmtStr )
+				.replace( "{balanceKmbt}", balanceKmbtStr )
+				.replace( "{balanceMetric}", balanceMetricStr )
+				.trim()
+				;
+			
+		}
+		
+		return results;
+	}
+	
+}

--- a/prison-core/src/main/java/tech/mcprison/prison/util/Bounds.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/util/Bounds.java
@@ -37,6 +37,10 @@ public class Bounds {
     
     private final int totalBlockCount;
 
+    private final int blockCountPerLayer;
+    
+    private final int totalLayers;
+
     
 	public enum Edges {
 		top,
@@ -135,10 +139,14 @@ public class Bounds {
         
         this.center = new Location(this.min.getWorld(), centerX, centerY, centerZ );
 
+        
+        this.totalLayers = (getyBlockMax() - getyBlockMin() + 1);
+        
+        this.blockCountPerLayer = (getxBlockMax() - getxBlockMin() + 1) *
+    							  (getzBlockMax() - getzBlockMin() + 1);
+        
         this.totalBlockCount = 
-        			(getyBlockMax() - getyBlockMin() + 1) *
-        			(getxBlockMax() - getxBlockMin() + 1) *
-        			(getzBlockMax() - getzBlockMin() + 1);
+        			totalLayers * blockCountPerLayer;
     }
 
     
@@ -279,10 +287,14 @@ public class Bounds {
         
         this.center = new Location(this.min.getWorld(), centerX, centerY, centerZ );
 
+        
+        this.totalLayers = (getyBlockMax() - getyBlockMin() + 1);
+        
+        this.blockCountPerLayer = (getxBlockMax() - getxBlockMin() + 1) *
+    							  (getzBlockMax() - getzBlockMin() + 1);
+        
         this.totalBlockCount = 
-        			(getyBlockMax() - getyBlockMin() + 1) *
-        			(getxBlockMax() - getxBlockMin() + 1) *
-        			(getzBlockMax() - getzBlockMin() + 1);
+        			totalLayers * blockCountPerLayer;
     }
 
     
@@ -548,6 +560,14 @@ public class Bounds {
 	public double getzMax()
 	{
 		return zMax;
+	}
+
+	public int getBlockCountPerLayer() {
+		return blockCountPerLayer;
+	}
+
+	public int getTotalLayers() {
+		return totalLayers;
 	}
 
 	public int getTotalBlockCount()

--- a/prison-core/src/main/java/tech/mcprison/prison/util/ExampleJavaDoubleVsBigDecimal.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/util/ExampleJavaDoubleVsBigDecimal.java
@@ -27,6 +27,24 @@ public class ExampleJavaDoubleVsBigDecimal {
 		for (String line : out) {
 			System.out.println( line );
 		}
+		
+		System.out.println();
+		System.out.println();
+		System.out.println();
+		
+		double a = 1.0;
+		double b = 0.014;
+		double c = a - b;
+		double d = c * 100d;
+		double e = d / 100d;
+		double f = ((a * 100d) - (b * 100d)) / 100.0d;
+		
+		System.out.println( 
+				String.format( "a = %f   b = %f   c = %f   d = %f   e = %f   f = %f" ,
+				a, b, c, d, e, f ) );
+		
+		System.out.println( c );
+		System.out.println( f );
 	}
 
 	

--- a/prison-core/src/main/java/tech/mcprison/prison/util/PrisonStatsUtil.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/util/PrisonStatsUtil.java
@@ -338,6 +338,12 @@ public class PrisonStatsUtil {
     		sb.append( Prison.get().getPlatform().dumpEventListenersBlockBreakEvents() );
     	}
     	
+    	if ( "blockPlace".equalsIgnoreCase( listenerType ) || "all".equalsIgnoreCase( listenerType ) ) {
+    		
+    		sb.append( "||Listeners blockPlace||" );
+    		sb.append( Prison.get().getPlatform().dumpEventListenersBlockPlaceEvents() );
+    	}
+    	
     	if ( "chat".equalsIgnoreCase( listenerType ) || "all".equalsIgnoreCase( listenerType ) ) {
     		
     		sb.append( "||Listeners chat||" );
@@ -356,6 +362,19 @@ public class PrisonStatsUtil {
     		sb.append( Prison.get().getPlatform().dumpEventListenersPlayerInteractEvents() );
     	}
 
+    	if ( "playerDropItem".equalsIgnoreCase( listenerType ) || "all".equalsIgnoreCase( listenerType ) ) {
+    		
+    		sb.append( "||Listeners playerDropItem||" );
+    		sb.append( Prison.get().getPlatform().dumpEventListenersPlayerDropItemEvents() );
+    	}
+    	
+    	if ( "playerPickupItem".equalsIgnoreCase( listenerType ) || "all".equalsIgnoreCase( listenerType ) ) {
+    		
+    		sb.append( "||Listeners playerPickupItem||" );
+    		sb.append( Prison.get().getPlatform().dumpEventListenersPlayerPickupItemEvents() );
+    	}
+    	
+    	
 		return sb;
 	}
 

--- a/prison-core/src/main/resources/lang/core/de_DE.properties
+++ b/prison-core/src/main/resources/lang/core/de_DE.properties
@@ -79,7 +79,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=8
+messages__version=9
 messages__auto_refresh=true
 
 
@@ -191,4 +191,32 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/en_GB.properties
+++ b/prison-core/src/main/resources/lang/core/en_GB.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=8
+messages__version=9
 messages__auto_refresh=true
 
 
@@ -191,4 +191,32 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/en_US.properties
+++ b/prison-core/src/main/resources/lang/core/en_US.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=9
+messages__version=10
 messages__auto_refresh=true
 
 
@@ -191,4 +191,33 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-10]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [9]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
+
 

--- a/prison-core/src/main/resources/lang/core/en_US.properties
+++ b/prison-core/src/main/resources/lang/core/en_US.properties
@@ -202,7 +202,7 @@ core_gui__prestige_name=&3Prestige name: %1
 # Header values will be used as is. Detail values identifies the placeholder to use.
 # Important: Every [] must be paired with a value or it will produce a runtime error:
 #            'Incorrect number of parameters: [Format specifier %s]
-core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-10]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
 core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
 core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
 core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
@@ -214,7 +214,7 @@ core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balan
 # {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
 # {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
 # {balanceFmt}, {balanceKmbt}, {balanceMetric}
-core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [9]
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
 core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
 core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
 core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}

--- a/prison-core/src/main/resources/lang/core/es_ES.properties
+++ b/prison-core/src/main/resources/lang/core/es_ES.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=8
+messages__version=9
 messages__auto_refresh=true
 
 
@@ -191,4 +191,32 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/fi_FI.properties
+++ b/prison-core/src/main/resources/lang/core/fi_FI.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=9
+messages__version=10
 messages__auto_refresh=true
 
 
@@ -191,4 +191,32 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/fr_FR.properties
+++ b/prison-core/src/main/resources/lang/core/fr_FR.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=9
+messages__version=10
 messages__auto_refresh=true
 
 
@@ -191,4 +191,32 @@ core_gui__multiplier=&3Multiplicateur: x %1
 core_gui__value=&3Valeur: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Nom de prestige: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/hu_HU.properties
+++ b/prison-core/src/main/resources/lang/core/hu_HU.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=8
+messages__version=9
 messages__auto_refresh=true
 
 
@@ -191,4 +191,32 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/it_IT.properties
+++ b/prison-core/src/main/resources/lang/core/it_IT.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=8
+messages__version=9
 messages__auto_refresh=true
 
 
@@ -191,4 +191,32 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/nl_BE.properties
+++ b/prison-core/src/main/resources/lang/core/nl_BE.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=8
+messages__version=9
 messages__auto_refresh=true
 
 
@@ -149,7 +149,15 @@ worldNotFound=De wereld %1 kon niet worden gevonden.
 
 core_gui__click_to_decrease=&3Click to decrease.
 core_gui__click_to_increase=&3Click to increase.
+
+
+core_gui__click_to_cancel=&3Click to cancel.
+core_gui__click_to_close=&3Click to close.
+core_gui__click_to_confirm=&3Click to confirm.
+core_gui__click_to_delete=&3Click to delete.
+core_gui__click_to_disable=&3Click to disable.
 core_gui__click_to_edit=&3Click to edit.
+core_gui__click_to_enable=&3Click to enable.
 core_gui__click_to_open=&3Click to open.
 
 
@@ -175,8 +183,41 @@ core_gui__page_next=&3Next page.
 core_gui__page_prior=&3Prior page.
 
 
+core_gui__money_earned=&3You earned &a$%1
 core_gui__price=&3Price: %1
 core_gui__confirm=&3Confirm: %1 %2
+core_gui__delay=&3Delay: %1 secs
 core_gui__multiplier=&3Multiplier: x %1
+core_gui__value=&3Value: %1
+core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
+
 

--- a/prison-core/src/main/resources/lang/core/nl_NL.properties
+++ b/prison-core/src/main/resources/lang/core/nl_NL.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=8
+messages__version=9
 messages__auto_refresh=true
 
 
@@ -191,4 +191,32 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/pt_PT.properties
+++ b/prison-core/src/main/resources/lang/core/pt_PT.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=3
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -101,6 +101,7 @@ core_text__just_now=just now
 core_text__ago=ago
 core_text__from_now=from now
 core_text__and=and
+core_text__time_units_prefix_spacer= 
 core_text__time_units_singular=year,month,week,day,hour,minute,second
 core_text__time_units_plural=years,months,weeks,days,hours,minutes,seconds
 core_text__time_units_short=y,m,w,d,h,m,s
@@ -182,6 +183,7 @@ core_gui__page_next=&3Pagina seguinte.
 core_gui__page_prior=&3Pagina anterior.
 
 
+core_gui__money_earned=&3You earned &a$%1
 core_gui__price=&3Preco: %1
 core_gui__confirm=&3Confirmar: %1 %2
 core_gui__delay=&3Atrado: %1 secs
@@ -189,4 +191,32 @@ core_gui__multiplier=&3Multiplicador: x %1
 core_gui__value=&3Valor: %1
 core_gui__permission=&3Permissão: &7%1
 core_gui__prestige_name=&3Nome do Prestige: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
 

--- a/prison-core/src/main/resources/lang/core/ro_RO.properties
+++ b/prison-core/src/main/resources/lang/core/ro_RO.properties
@@ -76,7 +76,7 @@
 #
 
 
-messages__version=3
+messages__version=4
 messages__auto_refresh=true
 
 
@@ -191,4 +191,33 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
+
 

--- a/prison-core/src/main/resources/lang/core/zh-CN.properties
+++ b/prison-core/src/main/resources/lang/core/zh-CN.properties
@@ -1,4 +1,3 @@
-
 #
 #  Prison is a Minecraft plugin for the prison game mode.
 #  Copyright (C) 2021 The Prison Team
@@ -77,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=7
+messages__version=8
 messages__auto_refresh=true
 
 
@@ -101,7 +100,8 @@ core_text__prefix=&3
 core_text__just_now=现在
 core_text__ago=以前
 core_text__from_now=后
-core_text__and=和
+core_text__and=�
+core_text__time_units_prefix_spacer= ��
 core_text__time_units_singular=年、月、周、日、时、分、秒
 core_text__time_units_plural=年、月、周、日、时、分、秒
 core_text__time_units_short=年、月、周、日、时、分、秒
@@ -118,6 +118,10 @@ core_tokens__set_amount=&3%1 now has &7%2 &3tokens.
 
 core_runCmd__name_required=A valid player name is required.
 core_runCmd__command_required=A command is required.
+
+
+core_prison_utf8_test=\u041F\u0440\u0438\u0432\u0435\u0442! \u0414\u0430\u0432\u0430\u0439 \u043F\u043E\u0441\u043C\u043E\u0442\u0440\u0438\u043C, \u0440\u0430\u0431\u043E\u0442\u0430\u0435\u0442 \u043B\u0438? Test 01
+
 
 # The following are the original messages and they will eventually be replaced.
 
@@ -179,6 +183,7 @@ core_gui__page_next=&3下一页
 core_gui__page_prior=&3上一页
 
 
+core_gui__money_earned=&3You earned &a$%1
 core_gui__price=&3价格：%1
 core_gui__confirm=&3确认：%1%2
 core_gui__delay=&3延迟：%1秒
@@ -186,4 +191,33 @@ core_gui__multiplier=&3倍数：x%1
 core_gui__value=&3值：%1
 core_gui__permission=&3权限：&7%1
 core_gui__prestige_name=&3声望名称：%1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
+
 

--- a/prison-core/src/main/resources/lang/core/zh_TW.properties
+++ b/prison-core/src/main/resources/lang/core/zh_TW.properties
@@ -76,7 +76,7 @@
 # like to share, please contact a staff member on our Discord server.  
 #Thanks for your contributions!
 #
-messages__version=8
+messages__version=9
 messages__auto_refresh=true
 
 
@@ -191,4 +191,33 @@ core_gui__multiplier=&3Multiplier: x %1
 core_gui__value=&3Value: %1
 core_gui__permission=&3Permission: &7%1
 core_gui__prestige_name=&3Prestige name: %1
+
+
+
+
+
+# For format, the edit codes need to be within []. A number defines the width
+# and negative numbers will left justify the values with padding. An empty []
+# will not add any padding. All values are treated as strings.
+# Header values will be used as is. Detail values identifies the placeholder to use.
+# Important: Every [] must be paired with a value or it will produce a runtime error:
+#            'Incorrect number of parameters: [Format specifier %s]
+core_ranks_topn__player_line_1_header_format=[4]  [-18] [-10] [11] [-8] [-12]
+core_ranks_topn__player_line_1_header_values=Rank, Player, PreDefRanks, Balance, r-Score, Penalty
+core_ranks_topn__player_line_2_header_format=[4] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_header_values=Rank, Ranks, r-Score, Player, Balance
+
+# For detail_values you can use any of the following placeholders, but they must pair up
+# with the detail_format's [].
+# {playerName}, {rankPosition}, {rankScore}, {rankScorePenalty},
+# {prestigeRank}, {defaultRank}, {prestigeDefaultRank},
+# {prestigeRankTag}, {defaultRankTag}, {prestigeDefaultRankTag},
+# {prestigeRankTagNoColor}, {defaultRankTagNoColor}, {prestigeDefaultRankTagNoColor}, 
+# {balanceFmt}, {balanceKmbt}, {balanceMetric}
+core_ranks_topn__player_line_1_detail_format= [-4] [-18] [-12] [10] [7] [10]
+core_ranks_topn__player_line_1_detail_values={rankPosition}, {playerName}, {prestigeDefaultRankTagNoColor}, {balanceKmbt}, {rankScore}, {rankScorePenalty}
+core_ranks_topn__player_line_2_detail_format= [-3] [-10] [7] [-18] [9]
+core_ranks_topn__player_line_2_detail_values={rankPosition}, {prestigeDefaultRankTagNoColor}, {rankScore}, {playerName}, {balanceKmbt}
+
+
 

--- a/prison-core/src/main/resources/lang/mines/de_DE.properties
+++ b/prison-core/src/main/resources/lang/mines/de_DE.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7Alle Minen %1 wurden zurückgesetzt in &3%2&7.
 reset_message=&7Alle Minen %1 wurden zurückgesetzt.
+skip_reset_message=
 not_allowed=&7Hier darfst du nicht verminen.
 autosmelt_enable=&bAutosmelt &7wurde aktiviert.
 autosmelt_disable=&bAutosmelt &7wurde deaktiviert.

--- a/prison-core/src/main/resources/lang/mines/en_US.properties
+++ b/prison-core/src/main/resources/lang/mines/en_US.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7Mine %1 will reset in &3%2&7.
 reset_message=&7The mine %1 has been reset.
+skip_reset_message=
 not_allowed=&7You are not allowed to mine here.
 autosmelt_enable=&bAutosmelt &7has been &aenabled&7.
 autosmelt_disable=&bAutosmelt &7has been &cdisabled&7.

--- a/prison-core/src/main/resources/lang/mines/es_ES.properties
+++ b/prison-core/src/main/resources/lang/mines/es_ES.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7Todas las minas %1 se reiniciarán en &3%2&7.
 reset_message=&7Todas las minas %1 han sido reiniciadas.
+skip_reset_message=
 not_allowed=&7No tienes permitido minar aquí.
 autosmelt_enable=&7La &bFundición Automática &7ha sido &aactivada&7.
 autosmelt_disable=&7La &bFundición Automática &7ha sido &cdesactivada&7.

--- a/prison-core/src/main/resources/lang/mines/fi_FI.properties
+++ b/prison-core/src/main/resources/lang/mines/fi_FI.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7Mine %1 resettaa &3%2&7.
 reset_message=&7mine %1 on resetattu.
+skip_reset_message=
 not_allowed=&7Et voi mainata täällä.
 autosmelt_enable=&bAutosmelt &7on &akäytössä&7.
 autosmelt_disable=&bAutosmelt &7on &cdisabloitu&7.

--- a/prison-core/src/main/resources/lang/mines/fr_FR.properties
+++ b/prison-core/src/main/resources/lang/mines/fr_FR.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7La mine %1 va se réinitialiser dans &3%2&7.
 reset_message=&7La mine %1 a été réinitialisée.
+skip_reset_message=
 not_allowed=&7Tu n'es pas autorisé à miner ici.
 autosmelt_enable=&bL'Autosmelt &7a été &aactivé&7.
 autosmelt_disable=&bL'Autosmelt &7a été &cdésactivé&7.

--- a/prison-core/src/main/resources/lang/mines/hu_HU.properties
+++ b/prison-core/src/main/resources/lang/mines/hu_HU.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7Minden %1 bánya újratöltve &3%2&7.
 reset_message=&7Az összes %1 bánya vissza lett állítva.
+skip_reset_message=
 not_allowed=&7A bányászás nem megengedett.
 autosmelt_enable=&bAz auto. égetés &7engedélyezve.
 autosmelt_disable=&bAz auto. égetés &7letiltva.

--- a/prison-core/src/main/resources/lang/mines/it_IT.properties
+++ b/prison-core/src/main/resources/lang/mines/it_IT.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7Tutte le miniere %1 stanno per essere resettate tra &3%2&7.
 reset_message=&7Tutte le miniere %1 sono state resettate.
+skip_reset_message=
 not_allowed=&7Non sei ammesso a scvare qua.
 autosmelt_enable=&bAutoFusione &7è stata &aabilitata&7.
 autosmelt_disable=&bAutoFusione &7è stata &cdisabilitata&7.

--- a/prison-core/src/main/resources/lang/mines/nl_BE.properties
+++ b/prison-core/src/main/resources/lang/mines/nl_BE.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7Alle mijnen %1 worden hersteld in &3%2&7.
 reset_message=&7Alle mijnen %1 zijn hersteld.
+skip_reset_message=
 not_allowed=&7Je mag hier niet mijnen.
 autosmelt_enable=&bAutosmelt &7is aangezet.
 autosmelt_disable=&bAutosmelt &7is afgezet.

--- a/prison-core/src/main/resources/lang/mines/nl_NL.properties
+++ b/prison-core/src/main/resources/lang/mines/nl_NL.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&Alle mijnen %1 worden hersteld in &3%2&7.
 reset_message=&7Alle mijnen %1 zijn hersteld.
+skip_reset_message=
 not_allowed=&7Je mag hier niet mijnen.
 autosmelt_enable=&bAutosmelt &7is aangezet.
 autosmelt_disable=&bAutosmelt &7is afgezet.

--- a/prison-core/src/main/resources/lang/mines/pt_PT.properties
+++ b/prison-core/src/main/resources/lang/mines/pt_PT.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7A Mina %1 vai resetar em &3%2&7.
 reset_message=&7A mina %1 resetou.
+skip_reset_message=
 not_allowed=&7Não podes minerar aqui.
 autosmelt_enable=&bAutosmelt &7foi &aativado&7.
 autosmelt_disable=&bAutosmelt &7foi &cdisativado&7.

--- a/prison-core/src/main/resources/lang/mines/ro_RO.properties
+++ b/prison-core/src/main/resources/lang/mines/ro_RO.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=4
+messages__version=5
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7Mina %1 va fi resetată &3%2&7.
 reset_message=&7Mina %1 a fost resetată.
+skip_reset_message=
 not_allowed=&7Nu ai voie să minezi aici.
 autosmelt_enable=&bAutosmelt-ul &7a fost &aactivat&7.
 autosmelt_disable=&bAutosmelt-ul &7a fost &cdezactivat&7.

--- a/prison-core/src/main/resources/lang/mines/zh-CN.properties
+++ b/prison-core/src/main/resources/lang/mines/zh-CN.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=3
+messages__version=4
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7矿区%1将在&3%2分钟后&7重置
 reset_message=&7矿区%1已经重置
+skip_reset_message=
 not_allowed=&7你没有在此处挖矿所需要的权限
 autosmelt_enable=&bAutoMelt&7已启用&7
 autosmelt_disable=&bAutoMelt&7已禁用&7

--- a/prison-core/src/main/resources/lang/mines/zh_TW.properties
+++ b/prison-core/src/main/resources/lang/mines/zh_TW.properties
@@ -60,7 +60,7 @@
 #
 
 
-messages__version=5
+messages__version=6
 messages__auto_refresh=true
 
 
@@ -69,6 +69,7 @@ messages__auto_refresh=true
 
 reset_warning=&7礦場 %1 將在 &3%2&7 分鐘後重置
 reset_message=&7礦場 %1 已經重置
+skip_reset_message=
 not_allowed=&7您沒有權限在此挖礦
 autosmelt_enable=&b自動冶煉 &7已被 &a啟用&7
 autosmelt_disable=&b自動冶煉 &7已被 &c停用&7

--- a/prison-core/src/main/resources/lang/ranks/en_US.properties
+++ b/prison-core/src/main/resources/lang/ranks/en_US.properties
@@ -61,6 +61,17 @@
 # NOTE: You can add line feeds to your messages by inserting the placeholder '{br}'.
 #
 
+## NOTE: Prison now supports the use of secondary placeholders on all "player" related messages.
+##       Just add these placeholders, in any position, combination, or quantity, to any 
+##       message's text.
+##       {player} {rank_default} {rank_tag_default} {rank_next_default} {rank_next_tag_default}
+##       {rank_prestiges} {rank_tag_prestiges} {rank_next_prestiges} {rank_next_tag_prestiges}
+##       Player based messages are generally messages sent to player. Not all messages are able
+##       to support these secondary placeholders; if you find one that is not supported, please
+##       contact RoyalBlueRanger in a support thread on the Prison discord server and I may
+##       be able to enable them.
+
+
 messages__version=29
 messages__auto_refresh=true
 

--- a/prison-core/src/main/resources/lang/ranks/fr_FR.properties
+++ b/prison-core/src/main/resources/lang/ranks/fr_FR.properties
@@ -58,6 +58,19 @@
 #       these are a very low level static component of the fallback messaging system within Prison.
 #       You will have to restart the server if you make any changes to the messages with these prefixes.
 #
+# NOTE: You can add line feeds to your messages by inserting the placeholder '{br}'.
+#
+
+## NOTE: Prison now supports the use of secondary placeholders on all "player" related messages.
+##       Just add these placeholders, in any position, combination, or quantity, to any 
+##       message's text.
+##       {player} {rank_default} {rank_tag_default} {rank_next_default} {rank_next_tag_default}
+##       {rank_prestiges} {rank_tag_prestiges} {rank_next_prestiges} {rank_next_tag_prestiges}
+##       Player based messages are generally messages sent to player. Not all messages are able
+##       to support these secondary placeholders; if you find one that is not supported, please
+##       contact RoyalBlueRanger in a support thread on the Prison discord server and I may
+##       be able to enable them.
+
 
 messages__version=28
 messages__auto_refresh=true

--- a/prison-core/src/main/resources/lang/ranks/pt_PT.properties
+++ b/prison-core/src/main/resources/lang/ranks/pt_PT.properties
@@ -58,6 +58,19 @@
 #       these are a very low level static component of the fallback messaging system within Prison.
 #       You will have to restart the server if you make any changes to the messages with these prefixes.
 #
+# NOTE: You can add line feeds to your messages by inserting the placeholder '{br}'.
+#
+
+## NOTE: Prison now supports the use of secondary placeholders on all "player" related messages.
+##       Just add these placeholders, in any position, combination, or quantity, to any 
+##       message's text.
+##       {player} {rank_default} {rank_tag_default} {rank_next_default} {rank_next_tag_default}
+##       {rank_prestiges} {rank_tag_prestiges} {rank_next_prestiges} {rank_next_tag_prestiges}
+##       Player based messages are generally messages sent to player. Not all messages are able
+##       to support these secondary placeholders; if you find one that is not supported, please
+##       contact RoyalBlueRanger in a support thread on the Prison discord server and I may
+##       be able to enable them.
+
 
 messages__version=6
 messages__auto_refresh=true

--- a/prison-core/src/main/resources/lang/ranks/zh-CN.properties
+++ b/prison-core/src/main/resources/lang/ranks/zh-CN.properties
@@ -58,6 +58,19 @@
 #       these are a very low level static component of the fallback messaging system within Prison.
 #       You will have to restart the server if you make any changes to the messages with these prefixes.
 #
+# NOTE: You can add line feeds to your messages by inserting the placeholder '{br}'.
+#
+
+## NOTE: Prison now supports the use of secondary placeholders on all "player" related messages.
+##       Just add these placeholders, in any position, combination, or quantity, to any 
+##       message's text.
+##       {player} {rank_default} {rank_tag_default} {rank_next_default} {rank_next_tag_default}
+##       {rank_prestiges} {rank_tag_prestiges} {rank_next_prestiges} {rank_next_tag_prestiges}
+##       Player based messages are generally messages sent to player. Not all messages are able
+##       to support these secondary placeholders; if you find one that is not supported, please
+##       contact RoyalBlueRanger in a support thread on the Prison discord server and I may
+##       be able to enable them.
+
 
 messages__version=25
 messages__auto_refresh=true

--- a/prison-core/src/main/resources/lang/ranks/zh_TW.properties
+++ b/prison-core/src/main/resources/lang/ranks/zh_TW.properties
@@ -58,6 +58,19 @@
 #       these are a very low level static component of the fallback messaging system within Prison.
 #       You will have to restart the server if you make any changes to the messages with these prefixes.
 #
+# NOTE: You can add line feeds to your messages by inserting the placeholder '{br}'.
+#
+
+## NOTE: Prison now supports the use of secondary placeholders on all "player" related messages.
+##       Just add these placeholders, in any position, combination, or quantity, to any 
+##       message's text.
+##       {player} {rank_default} {rank_tag_default} {rank_next_default} {rank_next_tag_default}
+##       {rank_prestiges} {rank_tag_prestiges} {rank_next_prestiges} {rank_next_tag_prestiges}
+##       Player based messages are generally messages sent to player. Not all messages are able
+##       to support these secondary placeholders; if you find one that is not supported, please
+##       contact RoyalBlueRanger in a support thread on the Prison discord server and I may
+##       be able to enable them.
+
 
 messages__version=9
 messages__auto_refresh=true

--- a/prison-core/src/test/java/tech/mcprison/prison/TestPlatform.java
+++ b/prison-core/src/test/java/tech/mcprison/prison/TestPlatform.java
@@ -385,7 +385,13 @@ public class TestPlatform implements Platform {
 					boolean forceLinersBottom, boolean forceLinersWalls ) {
 		
 	}
-	
+		
+	@Override
+	public String autoCreateMineLinerAssignment(ModuleElement eMine, 
+					boolean forceLinersBottom, boolean forceLinersWalls) {
+		return null;
+	}
+
 	@Override
 	public void autoCreateConfigureMines() {
 		
@@ -561,5 +567,9 @@ public class TestPlatform implements Platform {
 
 	public String getRankByFileName(String name) {
 		return "a";
+	}
+	
+	public Map<String, Object> loadYaml(File file) {
+		return new TreeMap<String, Object>();
 	}
 }

--- a/prison-core/src/test/java/tech/mcprison/prison/TestPlatform.java
+++ b/prison-core/src/test/java/tech/mcprison/prison/TestPlatform.java
@@ -572,4 +572,22 @@ public class TestPlatform implements Platform {
 	public Map<String, Object> loadYaml(File file) {
 		return new TreeMap<String, Object>();
 	}
+
+	@Override
+	public String dumpEventListenersBlockPlaceEvents() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String dumpEventListenersPlayerDropItemEvents() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String dumpEventListenersPlayerPickupItemEvents() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/prison-core/src/test/java/tech/mcprison/prison/TestPlayer.java
+++ b/prison-core/src/test/java/tech/mcprison/prison/TestPlayer.java
@@ -32,6 +32,7 @@ import tech.mcprison.prison.internal.Player;
 import tech.mcprison.prison.internal.block.Block;
 import tech.mcprison.prison.internal.inventory.Inventory;
 import tech.mcprison.prison.internal.scoreboard.Scoreboard;
+import tech.mcprison.prison.ranks.data.RankPlayer;
 import tech.mcprison.prison.util.Gamemode;
 import tech.mcprison.prison.util.Location;
 
@@ -260,13 +261,16 @@ public class TestPlayer
 
 	@Override
 	public void sendMessage(List<String> messages) {
-		// TODO Auto-generated method stub
 		
 	}
 
 	@Override
 	public Player getPlatformPlayer() {
-		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public RankPlayer getRankPlayer() {
 		return null;
 	}
 	

--- a/prison-core/src/test/java/tech/mcprison/prison/TestPlayer.java
+++ b/prison-core/src/test/java/tech/mcprison/prison/TestPlayer.java
@@ -251,5 +251,10 @@ public class TestPlayer
 	public void incrementMinecraftStatsDropCount( Player player, String blockName, int quantity) {
 		
 	}
+
+	@Override
+	public List<String> getSellAllMultiplierListings() {
+		return new ArrayList<>();
+	}
 	
 }

--- a/prison-core/src/test/java/tech/mcprison/prison/TestPlayer.java
+++ b/prison-core/src/test/java/tech/mcprison/prison/TestPlayer.java
@@ -256,5 +256,18 @@ public class TestPlayer
 	public List<String> getSellAllMultiplierListings() {
 		return new ArrayList<>();
 	}
+
+
+	@Override
+	public void sendMessage(List<String> messages) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public Player getPlatformPlayer() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 	
 }

--- a/prison-core/src/test/java/tech/mcprison/prison/selection/SelectionTest.java
+++ b/prison-core/src/test/java/tech/mcprison/prison/selection/SelectionTest.java
@@ -48,8 +48,9 @@ public class SelectionTest {
 
     @Before public void setUp() throws Exception {
     	TestPlatform testPlatform = new TestPlatform(temporaryFolder.newFolder("test"), false);
-        Prison.get()
-        		.init(testPlatform, "1.12.X-test.1", new File("plugins/Prison"));
+        Prison.get().init(testPlatform, "1.13.X-test.1");
+        
+        Prison.get().init(new File("plugins/Prison"));
     }
 
     @Test public void testSelection() throws Exception {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesBlockCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesBlockCommands.java
@@ -15,6 +15,7 @@ import tech.mcprison.prison.mines.data.Mine;
 import tech.mcprison.prison.output.BulletedListComponent;
 import tech.mcprison.prison.output.ChatDisplay;
 import tech.mcprison.prison.output.LogLevel;
+import tech.mcprison.prison.output.Output;
 import tech.mcprison.prison.output.RowComponent;
 import tech.mcprison.prison.placeholders.PlaceholdersUtil;
 
@@ -202,6 +203,8 @@ public class MinesBlockCommands
 
 		if ( includeTotals )
 		{
+			totals.setChance( totalChance );
+			
 			addBlockStats( m, totals, maxBlockNameLength, iFmt, dFmt, builder );
 		}
 
@@ -230,7 +233,9 @@ public class MinesBlockCommands
 
 		if ( totals )
 		{
-			String text = String.format( "&d%" + maxBlockNameLength + "s   Totals: ", " " );
+			String percent = dFmt.format( block.getChance() ) + "%";
+			int length = maxBlockNameLength - ( percent.length() == 7 ? -1 : 0);
+			String text = String.format( "&d%-" + length + "s   Totals: ", percent );
 			row.addTextComponent( text );
 		}
 		else
@@ -849,5 +854,23 @@ public class MinesBlockCommands
     }
 	
 
+    public void listBlockLayerStatsCommand( CommandSender sender, String mineName ) {
+    	
+        setLastMineReferenced(mineName);
+        
+        PrisonMines pMines = PrisonMines.getInstance();
+        Mine m = pMines.getMine(mineName);
+        
+        if ( m != null ) {
+        	
+        	Output.get().logInfo( "Mine %s Block Layer Stats:", m.getName() );
+        	
+        	List<String> layers = m.getTargetBlockStatsPerLevel();
+        	for ( String layer : layers ) {
+				Output.get().logInfo( "  " + layer );
+			}
+        	
+        }
+    }
 	
 }

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -1905,7 +1905,7 @@ public class MinesCommands
     @Command(identifier = "mines set resetTime", permissions = "mines.set", 
     		description = "Set a mine's auto reset time as expressed in seconds.")
     public void resetTimeCommand(CommandSender sender,
-        @Arg(name = "mineName", description = "The name of the mine to edit, or '*all' to apply to all mines.") String mineName,
+        @Arg(name = "mineName", description = "The name of the mine to edit, or '*all*' to apply to all mines.") String mineName,
         @Arg(name = "time", description = "Time in seconds for the mine to auto reset. " +
         		"With a minimum value of "+ MineData.MINE_RESET__TIME_SEC__MINIMUM + " seconds. " +
         				"Using '*disable*' will turn off the auto reset.  Use of "

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -226,6 +226,17 @@ public class MinesCommands
     }
     
     @Override
+    @Command(identifier = "mines block layerStats", permissions = "mines.block", onlyPlayers = false, 
+			description = "A Mine's list layer stats")
+	public void listBlockLayerStatsCommand( CommandSender sender,
+			@Arg(name = "mineName", description = "The name of the mine to generate block layer stats for.")
+					String mineName ) {
+    	
+    	super.listBlockLayerStatsCommand( sender, mineName );
+    }
+    
+    
+    @Override
     @Command(identifier = "mines block list", permissions = "mines.block", 
     				description = "Lists all of the blocks assigned to a mine.")
     public void listBlockCommand(CommandSender sender,
@@ -235,7 +246,6 @@ public class MinesCommands
     }
     
     @Override
-    
     @Command(identifier = "mines block constraint", permissions = "mines.block", 
 							description = "Optionally enable constraints on a mine's block generation. "
 							+ "Please note that 'excludeTop' and 'excludeBottom' uses the layer "

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -75,7 +75,7 @@ import tech.mcprison.prison.util.Text;
  * @author Dylan M. Perks
  */
 public class MinesCommands
-	extends MinesBlockCommands {
+	extends MinesImportCommands {
 	
 	public MinesCommands() {
 		super( "MinesCommands" );
@@ -91,6 +91,47 @@ public class MinesCommands
     		onlyPlayers = false, permissions = "prison.commands")
     public void minesSetSubcommands(CommandSender sender) {
     	sender.dispatchCommand( "mines set help" );
+    }
+    
+    
+    /*
+     * NOTE: The mines import commands are from the class MinesImportCommands.
+     * The command handler setups is here, but the code is within that class.
+     */
+    
+    
+    @Command(identifier = "mines import", 
+    		onlyPlayers = false, permissions = "prison.commands")
+    public void mineImport(CommandSender sender) {
+    	sender.dispatchCommand( "mines import help" );
+    }
+    
+    @Command(identifier = "mines import jetsPrisonMines", 
+    		description = "Imports mines that were created within the plugin JetsPrisonMines. "
+    				+ "Most settings will be brought over to prison. If the mine already "
+    				+ "exits within prison, it will be skipped. First run this command "
+    				+ "without the option 'save' to confirm what can be imported."
+    				+ " Prison will use the path "
+    				+ "'JetsPrisonMines/mines/' to search for all yaml files that are "
+    				+ "used to store the mine configs, but his can be overridden with the "
+    				+ "'path=' option. Use the option 'world=' to save to a different world "
+    				+ "which can be useful if the world does not exist on your server. "
+    				+ "", 
+    		onlyPlayers = true, permissions = "mines.set")
+    public void minesImportJetsPrisonMines( CommandSender sender,
+    		@Wildcard(join=true)
+        	@Arg(name = "options", 
+        	description = "Options. The following options can customize how prison will perform "
+        			+ "the imports. [addLiner path=<pathToMineFiles> world=<forcedWorld> save] "
+        			+ "'addLiner' will randomly generate a liner for each mine. "
+        			+ "'path=<pathToMineFiles>' the default path is 'JetsPrisonMines/mines/' and "
+        			+ "this option will override this path. "
+        			+ "'world=<forcedWorld>' is the world name to use for mine and spawn placemments, "
+        			+ "which will override the yaml file's world even if it exists on the server. "
+        			+ "'save' must be specified or the imported mines will not be saved.") 
+    			String options ) {
+    	
+    	super.importJetsPrisonMines(sender, options);
     }
     
     

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCommands.java
@@ -307,7 +307,7 @@ public class MinesCommands
         }
         mineName = mineName.trim();
 
-    	Player player = getPlayer( sender );
+    	Player player = sender.getPlatformPlayer();
     	
     	if ( !virtual && (player == null || !player.isOnline())) {
     		sendMessage( sender, "&3You must be a player in the game to run this command.  " +
@@ -601,7 +601,7 @@ public class MinesCommands
         @Arg(name = "options", def = "set",
         		description = "Options: Option to set or remove a spawn. [set *remove*]") String options ) {
 
-    	Player player = getPlayer( sender );
+    	Player player = sender.getPlatformPlayer();
     	
     	if (player == null || !player.isOnline()) {
     		sender.sendMessage( "&3You must be a player in the game to run this command." );
@@ -1037,7 +1037,7 @@ public class MinesCommands
         	
         	if ( !m.isVirtual() ) {
         		String worldName = m.getWorld().isPresent() ? m.getWorld().get().getName() : "&cmissing";
-        		Player player = sender == null ? null : getPlayer( sender );
+        		Player player = sender == null ? null : sender.getPlatformPlayer();
         		chatDisplay.addText("&3World: &7%-10s  &3Center: &7%s   &3%s &7%s",
         				worldName,
         				m.getBounds().getCenter().toBlockCoordinates(), 
@@ -1512,7 +1512,7 @@ public class MinesCommands
             @Arg(name = "page", def = "1", 
             	description = "Page of search results (optional) [1-n, ALL]") String page 
     		) {
-    	Player player = getPlayer( sender );
+    	Player player = sender.getPlatformPlayer();
     	
     	MineSortOrder sortOrder = MineSortOrder.fromString( sort );
     	
@@ -1953,7 +1953,7 @@ public class MinesCommands
         	Output.get().sendInfo( sender, message );
         	
         	// Server Log message:
-        	Player player = getPlayer( sender );
+        	Player player = sender.getPlatformPlayer();
         	Output.get().logInfo( "%s :: Changed by: %s", message,
         								(player == null ? "console" : player.getDisplayName()) );
         } 
@@ -2032,7 +2032,7 @@ public class MinesCommands
     	        				mine.getTag(), resetTime );
     	        		
     	        		// Server Log message:
-    	        		Player player = getPlayer( sender );
+    	        		Player player = sender.getPlatformPlayer();
     	        		Output.get().logInfo( "&bmines set resettime&7: &b%s &7set &b%s &7resetTime to &b%d", 
     	        				(player == null ? "console" : player.getDisplayName()), mine.getTag(), resetTime  );
     				}
@@ -2078,7 +2078,7 @@ public class MinesCommands
         		Output.get().sendInfo( sender, "&7mines set resettime: &b%s &7resetTime set to &b%d", m.getTag(), resetTime );
         		
         		// Server Log message:
-        		Player player = getPlayer( sender );
+        		Player player = sender.getPlatformPlayer();
         		Output.get().logInfo( "&bmines set resettime&7: &b%s &7set &b%s &7resetTime to &b%d", 
         				(player == null ? "console" : player.getDisplayName()), m.getTag(), resetTime  );
         	}
@@ -2187,7 +2187,7 @@ public class MinesCommands
 		}
 		
 		// Server Log message:
-		Player player = getPlayer( sender );
+		Player player = sender.getPlatformPlayer();
 		Output.get().logInfo( "&7Mine &b%s Zero Block Reset Delay: &b%s &7set it to &b%s &7sec",
 				(player == null ? "console" : player.getDisplayName()), 
 				m, dFmt.format( resetTime )  );
@@ -2286,7 +2286,7 @@ public class MinesCommands
 		Output.get().sendInfo( sender, message );
 		
 		// Server Log message:
-		Player player = getPlayer( sender );
+		Player player = sender.getPlatformPlayer();
 		Output.get().logInfo( "%s :: Changed by: %s", message,
 									(player == null ? "console" : player.getDisplayName()) );
 	}
@@ -2714,7 +2714,7 @@ public class MinesCommands
         PrisonMines pMines = PrisonMines.getInstance();
         Mine m = pMines.getMine(mineName);
         
-        Player player = getPlayer( sender );
+        Player player = sender.getPlatformPlayer();
         
 //        if ( !m.isEnabled() ) {
 //        	sender.sendMessage( "&cMine is disabled&7. Use &a/mines info &7for possible cause." );
@@ -3413,7 +3413,7 @@ public class MinesCommands
     	}
     	
     	
-    	Player player = getPlayer( sender );
+    	Player player = sender.getPlatformPlayer();
     	
     	Player playerAlt = getOnlinePlayer( playerName );
     	
@@ -3517,7 +3517,7 @@ public class MinesCommands
     public void mineTpTop(CommandSender sender ) {
     	
 
-    	Player player = getPlayer( sender );
+    	Player player = sender.getPlatformPlayer();
     	//oboolean isOp = sender.isOp();
     	
     	
@@ -3610,7 +3610,7 @@ public class MinesCommands
     				description = "Identifies what mines you are in, or are the closest to." )
     public void mineWhereAmI(CommandSender sender) {
     	
-    	Player player = getPlayer( sender );
+    	Player player = sender.getPlatformPlayer();
     	
     	if (player == null || !player.isOnline()) {
     		sender.sendMessage( "&3You must be a player in the game to run this command." );
@@ -3723,7 +3723,7 @@ public class MinesCommands
     		onlyPlayers = false )
     public void wandCommand(CommandSender sender) {
     	
-    	Player player = getPlayer( sender );
+    	Player player = sender.getPlatformPlayer();
     	
     	if (player == null || !player.isOnline()) {
     		sender.sendMessage( "&3You must be a player in the game to run this command." );

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCoreCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesCoreCommands.java
@@ -78,4 +78,25 @@ public class MinesCoreCommands
 		return sb.toString();
 	}
 
+	
+	protected String extractParameter( String key, String options ) {
+		return extractParameter( key, options, true );
+	}
+	
+	protected String extractParameter( String key, String options, boolean tryLowerCase ) {
+		String results = null;
+		int idx = options.indexOf( key );
+		if ( idx != -1 ) {
+			int idxEnd = options.indexOf( " ", idx );
+			if ( idxEnd == -1 ) {
+				idxEnd = options.length();
+			}
+			results = options.substring( idx, idxEnd );
+		}
+		else if ( tryLowerCase ) {
+			// try again, but lowercase the key
+			results = extractParameter( key.toLowerCase(), options, false );
+		}
+		return results;
+	}
 }

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesImportCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesImportCommands.java
@@ -1,0 +1,381 @@
+package tech.mcprison.prison.mines.commands;
+
+import java.io.File;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import tech.mcprison.prison.Prison;
+import tech.mcprison.prison.internal.CommandSender;
+import tech.mcprison.prison.internal.World;
+import tech.mcprison.prison.internal.block.PrisonBlock;
+import tech.mcprison.prison.internal.block.PrisonBlockTypes;
+import tech.mcprison.prison.mines.PrisonMines;
+import tech.mcprison.prison.mines.data.Mine;
+import tech.mcprison.prison.mines.data.Mine.MineType;
+import tech.mcprison.prison.mines.data.MineData.MineNotificationMode;
+import tech.mcprison.prison.mines.features.MineLinerBuilder;
+import tech.mcprison.prison.mines.features.MineLinerBuilder.LinerPatterns;
+import tech.mcprison.prison.output.Output;
+import tech.mcprison.prison.selection.Selection;
+import tech.mcprison.prison.util.Location;
+import tech.mcprison.prison.util.Bounds.Edges;
+
+public class MinesImportCommands
+	extends MinesBlockCommands {
+
+	
+	public MinesImportCommands( String cmdGroup ) {
+		super( cmdGroup );
+	}
+	
+	
+
+    
+    public void importJetsPrisonMines( CommandSender sender,
+    			String options ) {
+
+    	boolean save = false;
+    	boolean addLiner = false;
+    	
+    	String path = "JetsPrisonMines//mines//";
+
+    	String worldForced = "";
+				
+//		if ( options.contains( "testImport" ) ) {
+//			testImport = true;
+//			list = true;
+//			options = options.replace( "testImport", "" ).trim();
+//		}
+//		
+//		if ( options.contains( "list" ) ) {
+//			testImport = false;
+//			list = true;
+//			options = options.replace( "list", "" ).trim();
+//		}
+		
+		if ( options.contains( "save" ) ) {
+			save = true;
+			options = options.replace( "save", "" ).trim();
+		}
+		
+		if ( options.contains( "addLiner" ) ) {
+			addLiner = true;
+			options = options.replace( "addLiner", "" ).trim();
+		}
+		
+		String pathStr = extractParameter("path=", options);
+		if ( pathStr != null ) {
+			options = options.replace( pathStr, "" );
+			pathStr = pathStr.replace( "path=", "" ).trim();
+			
+			path = pathStr;
+		}
+		
+		String worldStr = extractParameter("world=", options);
+		if ( worldStr != null ) {
+			options = options.replace( worldStr, "" );
+			worldStr = worldStr.replace( "world=", "" ).trim();
+			
+			worldForced = worldStr;
+		}
+
+		File dirPlugins = Prison.get().getPlatform().getPluginDirectory().getParentFile();
+		File dirMines = new File( dirPlugins, path );
+		
+		if ( !dirMines.exists() || !dirMines.isDirectory() ) {
+			sender.sendMessage( 
+					String.format( 
+							"Error: The path for JetsPrisonMines' mines does not exist: '%s'",
+							dirMines.getAbsolutePath() ) );
+				
+			return;
+		}
+		
+		DecimalFormat iFmt = Prison.get().getDecimalFormatInt();
+		List<File> files = Arrays.asList( dirMines.listFiles() );
+		
+		PrisonMines pMines = PrisonMines.getInstance();
+		
+		sender.sendMessage( 
+				String.format( 
+						"Prison import from JetsPrisonMines' mines: '%s'",
+						dirMines.getAbsolutePath() ) );
+		sender.sendMessage( 
+				String.format( 
+						"Mines to import: '%d'",
+						files.size() ) );
+		
+		int alreadyExists = 0;
+		int failed = 0;
+		int saved = 0;
+		int savable = 0;
+		
+		for ( File f : files ) {
+
+			if ( f.exists() && f.isFile() ) {
+				
+				Mine mine = convertJetsPrisonMines( f, worldForced );
+				
+				String status = "";
+				if ( mine == null ) {
+					failed++;
+					status = "(failed)";
+				}
+				else if ( pMines.getMine( mine.getName() ) != null ) {
+					alreadyExists++;
+					status = "(alreadyExists)";
+				}
+				else if ( save ) {
+					pMines.getMineManager().add(mine);
+					pMines.getMineManager().saveMine( mine );
+					
+					if ( addLiner ) {
+						Prison.get().getPlatform().autoCreateMineLinerAssignment( 
+								mine, true, true );
+					}
+					
+					saved++;
+					status = "(saved)";
+				}
+				else {
+					savable++;
+					status = "(savable)";
+				}
+				
+				sender.sendMessage( 
+						String.format( 
+								"  %-14s   %7s bytes   %s",
+								f.getName(), iFmt.format(f.length()),
+								status ) );
+			}
+		}
+		
+		if ( addLiner ) {
+			List<Mine> mines = new ArrayList<>();
+	    	
+			mines.addAll( pMines.getMines() );
+	    	
+	    	for ( Mine mine : mines )
+			{
+	    		if ( !mine.isVirtual() ) {
+	    			
+	    			for (Edges edge : Edges.values() ) {
+						
+	    				LinerPatterns linerPattern = LinerPatterns.fromString( 
+	    							mine.getLinerData().getEdge(edge) );
+	    				
+	    				boolean force = mine.getLinerData().getForce(edge);
+	    				boolean useTracer = false;
+	    				
+	    				new MineLinerBuilder( mine, edge, linerPattern, force, useTracer );
+					}
+	    			
+	    		}
+			}
+		}
+
+		sender.sendMessage( 
+				String.format( 
+						"Impored Mines:  Saved: %d  AlreadyExists: %d  Saveable: %d  Failed: %d", 
+						saved, alreadyExists, savable, failed ));
+    }
+
+
+
+
+	private Mine convertJetsPrisonMines(File f, String worldForced ) {
+		Mine mine = null;
+
+		Map<String,Object> yaml = null;
+		
+		try {
+			yaml = Prison.get().getPlatform().loadYaml( f );
+			
+			String mineName = (String) yaml.get( "mine_name" );
+			
+			
+			List<String> blocks = getYamlListString( yaml, "blocks" );
+			
+			String spawnWorld = worldForced != null && worldForced.length() > 0 ?
+					worldForced :
+						getYamlString( yaml, "teleport_location.world" );
+			double spawnX = getYamlDouble( yaml, "teleport_location.x" );
+			double spawnY = getYamlDouble( yaml, "teleport_location.y" );
+			double spawnZ = getYamlDouble( yaml, "teleport_location.z" );
+			double spawnPitch = getYamlDouble( yaml, "teleport_location.pitch" );
+			double spawnYaw = getYamlDouble( yaml, "teleport_location.yaw" );
+			
+			String locWorld =  worldForced != null && worldForced.length() > 0 ?
+					worldForced :
+						getYamlString( yaml, "region.world" );
+			double xMin = getYamlInteger( yaml, "region.xmin" );
+			double yMin = getYamlInteger( yaml, "region.ymin" );
+			double zMin = getYamlInteger( yaml, "region.zmin" );
+			double xMax = getYamlInteger( yaml, "region.xmax" );
+			double yMax = getYamlInteger( yaml, "region.ymax" );
+			double zMax = getYamlInteger( yaml, "region.zmax" );
+			
+
+			boolean rUseTimer = getYamlBoolean( yaml, "reset.use_timer" );
+			int rTimer = getYamlInteger( yaml, "reset.timer" );
+			boolean rUsePercentage = getYamlBoolean( yaml, "reset.use_percentage" );
+			double rPercentage = getYamlDouble( yaml, "reset.percentage" );
+			
+			boolean rUseMessages = getYamlBoolean( yaml, "reset.use_messages" );
+			int rBlocksMined = getYamlInteger( yaml, "reset.blocks_mined" );
+			
+
+			World sWorld = Prison.get().getPlatform().getWorld( spawnWorld ).orElse(null);
+			Location spawn = new Location( sWorld, spawnX, spawnY, spawnZ, 
+							(float) spawnPitch, (float) spawnYaw );
+
+					
+			World lWorld = Prison.get().getPlatform().getWorld( locWorld ).orElse(null);
+			Location locMin = new Location( lWorld, xMin, yMin, zMin );
+			Location locMax = new Location( lWorld, xMax, yMax, zMax );
+			Selection mSel = new Selection( locMin, locMax);
+
+			
+			boolean logInfo = false;
+			mine = new Mine( mineName, mSel, MineType.primary, logInfo );
+			
+			String tag = "&5[&d+" + mineName + "&5]";
+			mine.setTag( tag );
+			
+			mine.setHasSpawn( false );
+			
+			if ( spawn != null ) {
+				mine.setSpawn( spawn );
+				mine.setHasSpawn( true );
+			}
+			
+			if ( rUseTimer ) {
+				// reset time in seconds:
+				int time = rTimer * 60;
+				mine.setResetTime(time);
+			}
+			else {
+				// value of -1 disables resets by time:
+				mine.setResetTime( -1 );
+			}
+			
+			if ( rUsePercentage ) {
+				mine.setResetThresholdPercent( rPercentage );
+			}
+			
+			if ( rUseMessages ) {
+				mine.setNotificationMode( MineNotificationMode.within );
+			}
+			else {
+				mine.setNotificationMode( MineNotificationMode.disabled );
+			}
+			
+			mine.setBlockBreakCount(rBlocksMined);
+			
+			PrisonBlockTypes prisonBlockTypes = Prison.get().getPlatform().getPrisonBlockTypes();
+			 
+			for (String blockDetails : blocks) {
+				
+				String[] bd = blockDetails.split( ":" );
+				
+				String blockName = bd.length > 0 ? bd[0] : null;
+				String chanceStr = bd.length > 1 ? bd[1] : "1.0";
+				
+				PrisonBlock prisonBlock = prisonBlockTypes.getBlockTypesByName( blockName );
+				
+				if ( prisonBlock != null ) {
+					
+					double chance = 1.0;
+					
+					try {
+						chance = Double.parseDouble(chanceStr);
+					} 
+					catch (NumberFormatException e) {
+					}
+					
+					prisonBlock.setChance( chance );
+					
+					mine.addPrisonBlock( prisonBlock );
+				}
+			}
+			
+			
+			// Check if one of the blocks is effected by gravity, and if so, set that indicator.
+			mine.checkGravityAffectedBlocks();
+		} 
+		catch (Exception e) {
+
+			String message = String.format( "Could not %s: %s [%s]",
+					(yaml == null ? "parse mine file" : 
+						mine == null ? "generate mine" :
+							"fully configure mine"),
+					f.getName(), 
+					e.getMessage());
+			Output.get().logInfo( message );
+		}
+		
+		return mine;
+	}
+	
+	private String getYamlString( Map<String,Object> yaml, String key ) {
+		String results = null;
+		
+		try {
+			results = (String) yaml.get( key );
+		} 
+		catch (Exception e) {
+		}
+		
+		return results;
+	}
+	private double getYamlDouble( Map<String,Object> yaml, String key ) {
+		double results = 0;
+		
+		try {
+			results = (Double) yaml.get( key );
+		} 
+		catch (Exception e) {
+		}
+		
+		return results;
+	}
+	private int getYamlInteger( Map<String,Object> yaml, String key ) {
+		int results = 0;
+		
+		try {
+			results = (Integer) yaml.get( key );
+		} 
+		catch (Exception e) {
+		}
+		
+		return results;
+	}
+	private boolean getYamlBoolean( Map<String,Object> yaml, String key ) {
+		boolean results = false;
+		
+		try {
+			results = (Boolean) yaml.get( key );
+		} 
+		catch (Exception e) {
+		}
+		
+		return results;
+	}
+	@SuppressWarnings("unchecked")
+	private List<String> getYamlListString( Map<String,Object> yaml, String key ) {
+		List<String> results = new ArrayList<>();
+		
+		try {
+			results = new ArrayList<>( (List<String>) yaml.get(key) );
+		} 
+		catch (Exception e) {
+		}
+		
+		return results;
+	}
+
+}
+	

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesImportCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesImportCommands.java
@@ -233,6 +233,13 @@ public class MinesImportCommands
 			boolean rUseMessages = getYamlBoolean( yaml, "reset.use_messages" );
 			int rBlocksMined = getYamlInteger( yaml, "reset.blocks_mined" );
 			
+			
+			if ( mineName == null || mineName.trim().length() == 0 ||
+					spawnWorld == null || spawnWorld.trim().length() == 0 ||
+					locWorld == null || locWorld.trim().length() == 0 ) {
+				return mine;
+			}
+				
 
 			World sWorld = Prison.get().getPlatform().getWorld( spawnWorld ).orElse(null);
 			Location spawn = new Location( sWorld, spawnX, spawnY, spawnZ, 

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesImportCommands.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/commands/MinesImportCommands.java
@@ -147,7 +147,7 @@ public class MinesImportCommands
 				
 				sender.sendMessage( 
 						String.format( 
-								"  %-14s   %7s bytes   %s",
+								"  %-18s  %7s bytes   %s",
 								f.getName(), iFmt.format(f.length()),
 								status ) );
 			}
@@ -188,6 +188,12 @@ public class MinesImportCommands
 
 	private Mine convertJetsPrisonMines(File f, String worldForced ) {
 		Mine mine = null;
+		
+		
+		if ( !f.isFile() || !f.canRead() || f.length() == 0 ) {
+			return mine;
+		}
+		
 
 		Map<String,Object> yaml = null;
 		

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/Mine.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/Mine.java
@@ -113,7 +113,7 @@ public class Mine
     	this( name, selection, MineType.primary );
     }
     
-    public Mine(String name, Selection selection, MineType mineType) {
+    public Mine(String name, Selection selection, MineType mineType, boolean logInfo ) {
     	super();
     	
     	setName(name);
@@ -125,7 +125,7 @@ public class Mine
     	}
     	else {
     		
-    		setBounds(selection.asBounds());
+    		setBounds(selection.asBounds(), logInfo );
     		
     		setWorldName( getBounds().getMin().getWorld().getName());
     		
@@ -134,6 +134,11 @@ public class Mine
         
         // Kick off the initialize:
         initialize();
+    }
+    
+    public Mine(String name, Selection selection, MineType mineType) {
+    	this( name, selection, mineType, true );
+		
     }
     
     /**

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/Mine.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/Mine.java
@@ -34,6 +34,7 @@ import tech.mcprison.prison.mines.features.MineBlockEvent;
 import tech.mcprison.prison.mines.features.MineLinerData;
 import tech.mcprison.prison.mines.managers.MineManager;
 import tech.mcprison.prison.output.Output;
+import tech.mcprison.prison.placeholders.PlaceholderStringCoverter;
 import tech.mcprison.prison.selection.Selection;
 import tech.mcprison.prison.sorting.PrisonSortable;
 import tech.mcprison.prison.store.Document;
@@ -47,7 +48,7 @@ import tech.mcprison.prison.util.ObsoleteBlockType;
 @SuppressWarnings( "deprecation" )
 public class Mine 
 	extends MineScheduler 
-	implements PrisonSortable, Comparable<Mine> {
+	implements PrisonSortable, Comparable<Mine>, PlaceholderStringCoverter {
 	
 	
 	public enum MineType {
@@ -867,5 +868,160 @@ public class Mine
 	public int compareTo( Mine o ) {
 		return getName().toLowerCase().compareTo( o.getName().toLowerCase() );
 	}
+	
+	
+
+	@Override
+	public String getStringPlaceholders() {
+		return "{mine} {mine_tag} {mine_world} {mine_type} {mine_group} " +
+				"{mine_rank} {mine_air_count} {mine_player_count} " +
+				"{mine_block_break_count} {mine_block_remaining_count} {mine_block_remaining_percent} " +
+				"{mine_blocks_mined_total} {mine_reset_time_sec} {mine_reset_time_remaining_sec} " +
+				"{mine_block_[block]_name} {mine_block_[block]_type} {mine_block_[block]_placed} " +
+				"{mine_block_[block]_remaining} {mine_block_[block]_total} {mine_block_[block]_chance}";
+	}
+
+	
+    /**
+     * <p>This function will provide support for secondary placeholders for all mine related placeholders.
+     * These secondary placeholders are in addition to the preexisting positional placeholders
+     * that are hard coded for the specific parameters. 
+     * </p>
+     * 
+     * <p>These secondary placeholders can be inserted anywhere in the message.
+     * </p>
+     * 
+     * <ul>
+     * 	<li>{mine}</li>
+     * 	<li>{mine_tag}</li>
+     * 	<li>{mine_world}</li>
+     * 	<li>{mine_type}</li>
+     * 	<li>{mine_group}</li>
+     * 
+     * 	<li>{mine_rank}</li>
+     * 	<li>{mine_air_count}</li>
+     * 	<li>{mine_player_count}</li>
+     * 
+     * 	<li>{mine_block_break_count}</li>
+     *  <li>{mine_block_remaining_count}</li>
+     *  <li>{mine_block_remaining_percent}</li>
+     *  <li>{mine_blocks_mined_total}</li>
+     *  <li>{mine_reset_time_sec}</li>
+     *  <li>{mine_reset_time_remaining_sec}</li>
+     *  
+     *  <li>{mine_block_<block>_name}</li>
+     *  <li>{mine_block_<block>_type}</li>
+     *  <li>{mine_block_<block>_placed}</li>
+     *  <li>{mine_block_<block>_remaining}</li>
+     *  <li>{mine_block_<block>_total}</li>
+     *  <li>{mine_block_<block>_chance}</li>
+
+     * 
+     *  <li>{mine} {mine_tag} {mine_world} {mine_type} {mine_group}
+	 *		{mine_rank} {mine_air_count} {mine_player_count} 
+	 *		{mine_block_break_count} {mine_block_remaining_count} {mine_block_remaining_percent}
+	 *		{mine_blocks_mined_total} {mine_reset_time_sec} {mine_reset_time_remaining_sec}
+	 *		{mine_block_[block]_name} {mine_block_[block]_type} {mine_block_[block]_placed}
+	 *		{mine_block_[block]_remaining} {mine_block_[block]_total} {mine_block_[block]_chance}
+	 *  </li>
+     * 
+     * </ul>
+     * 
+     * @param rankPlayer
+     * @param results
+     * @return
+     */
+	@Override
+	public String convertStringPlaceholders(String results) {
+
+		Mine mine = this;
+		
+		if ( mine != null ) {
+			
+			results = applySecondaryPlaceholdersCheck( "{mine}", mine.getName(), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_tag}", mine.getTag(), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_world}", mine.getWorldName(), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_type}", mine.getMineType().name(), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_group}", mine.getMineGroup().getName(), results );
+
+			results = applySecondaryPlaceholdersCheck( "{mine_rank}", mine.getRankString(), results );
+			
+			results = applySecondaryPlaceholdersCheck( "{mine_air_count}", 
+					Integer.toString( mine.getAirCount()), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_player_count}", 
+					Integer.toString( mine.getPlayerCount()), results );
+			
+			results = applySecondaryPlaceholdersCheck( "{mine_block_break_count}", 
+					Integer.toString( mine.getBlockBreakCount()), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_block_remaining_count}", 
+					Integer.toString( mine.getRemainingBlockCount()), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_block_remaining_percent}", 
+					Double.toString( (mine.getPercentRemainingBlockCount() * 100.0d )), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_blocks_mined_total}", 
+					Long.toString( mine.getTotalBlocksMined()), results );
+			
+			results = applySecondaryPlaceholdersCheck( "{mine_reset_time_sec}", 
+					Integer.toString( mine.getResetTime()), results );
+			results = applySecondaryPlaceholdersCheck( "{mine_reset_time_remaining_sec}", 
+					Double.toString( mine.getRemainingTimeSec()), results );
+			
+			
+			Set<String> keys = mine.getBlockStats().keySet();
+			for (String key : keys) {
+				PrisonBlockStatusData blockStat = mine.getBlockStats().get( key );
+				
+				String bName = blockStat.getBlockName().toLowerCase();
+				String type = blockStat.getBlockType().name();
+				
+				long placed = blockStat.getBlockPlacedCount();
+				long remaining = blockStat.getBlockPlacedCount() - blockStat.getBlockCountUnsaved();
+				long total = blockStat.getBlockCountTotal();
+				
+				Double chance = blockStat.getChance() * 100.0d;
+				
+				results = applySecondaryPlaceholdersCheck( "{mine_block_" + bName + "_name}", 
+						bName, results );
+				results = applySecondaryPlaceholdersCheck( "{mine_block_" + bName + "_type}", 
+						type, results );
+
+				results = applySecondaryPlaceholdersCheck( "{mine_block_" + bName + "_placed}", 
+						Long.toString( placed ), results );
+				results = applySecondaryPlaceholdersCheck( "{mine_block_" + bName + "_remaining}", 
+						Long.toString( remaining ), results );
+				results = applySecondaryPlaceholdersCheck( "{mine_block_" + bName + "_total}", 
+						Long.toString( total ), results );
+				results = applySecondaryPlaceholdersCheck( "{mine_block_" + bName + "_chance}", 
+						Double.toString( chance ), results );
+				
+			}
+			
+
+			
+		}
+		
+		return results;
+	}
+	
+
+	/**
+	 * <p>Ths function will perform individual replacements of the given placeholders, but
+	 * if the placeholder does not exist, then it will not change anything with the results
+	 * and it will be just passed through.
+	 * </p>
+	 * 
+	 * @param placeholder
+	 * @param value
+	 * @param results
+	 * @return
+	 */
+	private String applySecondaryPlaceholdersCheck( String placeholder, String value, String results) {
+
+		if ( results.contains( placeholder ) && value != null ) {
+			results = results.replace( placeholder, value );
+		}
+		
+		return results;
+	}
+
 
 }

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineData.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineData.java
@@ -791,7 +791,7 @@ public abstract class MineData
     		block.setRangeBlockCountHigh( -1 );
     		block.setRangeBlockCountLowLimit( -1 );
     		block.setRangeBlockCountHighLimit( -1 );
-    		block.setIncludeInLayerCalculations( true );
+//    		block.setIncludeInLayerCalculations( true );
 		}
     	
     	for ( PrisonBlockStatusData block : getPrisonBlocks() ) {
@@ -802,7 +802,7 @@ public abstract class MineData
     		block.setRangeBlockCountHigh( -1 );
     		block.setRangeBlockCountLowLimit( -1 );
     		block.setRangeBlockCountHighLimit( -1 );
-    		block.setIncludeInLayerCalculations( true );
+//    		block.setIncludeInLayerCalculations( true );
     	}
     	
 //    	for ( PrisonBlockStatusData blockStats : getBlockStats().values() ) {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineData.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineData.java
@@ -406,6 +406,10 @@ public abstract class MineData
         return bounds;
     }
 
+    public void setBounds(Bounds bounds ) {
+    	setBounds( bounds, true );
+    }
+    
     /**
      * <p>(Re)defines the boundaries for this mine.
      * </p>
@@ -427,7 +431,7 @@ public abstract class MineData
      *
      * @param bounds the new boundaries
      */
-    public void setBounds(Bounds bounds) {
+    public void setBounds(Bounds bounds, boolean logInfo ) {
     	this.bounds = bounds;
     	
     	// if Bounds is null, then clear out the world fields and set mine to virtual and disable the mine:
@@ -454,7 +458,10 @@ public abstract class MineData
         		setVirtual( false );
         		setEnabled( true );
         		
-        		Output.get().logInfo( "&7Mine " + getTag() + "&7: world has been set and is now enabled." );
+        		if ( logInfo ) {
+        			Output.get().logInfo( "&7Mine " + getTag() + "&7: world has been set and is now enabled." );
+        		}
+        		
         	}
         	else {
         		setEnabled( false );
@@ -1084,14 +1091,20 @@ public abstract class MineData
 		this.hasSpawn = hasSpawn;
 	}
 
-	/*
+	/**
 	 * <p>This is the reset time for the mine, in seconds.
 	 * A value of -1 means no timed resets.  They will have to be done manually.
 	 * </p>
-	 */
+	 **/
 	public int getResetTime() {
 		return resetTime;
 	}
+	/**
+	 * <p>This is the reset time for the mine, in seconds.
+	 * A value of -1 means no timed resets.  They will have to be done manually.
+	 * </p>
+	 * @param resetTime
+	 */
 	public void setResetTime( int resetTime ) {
 		this.resetTime = resetTime;
 	}

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineLevelBlockListData.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineLevelBlockListData.java
@@ -5,11 +5,14 @@ import java.util.List;
 import java.util.Random;
 
 import tech.mcprison.prison.internal.block.PrisonBlock;
+import tech.mcprison.prison.output.Output;
 
 public class MineLevelBlockListData
 {
 
 	private int currentMineLevel;
+	
+	private int maxMineLevel;
 	
 	private Mine mine;
 	
@@ -17,16 +20,23 @@ public class MineLevelBlockListData
 	
 	private List<PrisonBlock> selectedBlocks;
 	
+	private PrisonBlock fillerBlock;
+	
 	private double totalChance = 0d;
 	
 	private double selectedChance = 0d;
 	
 	private double airChance = 0d;
+	
+	private boolean errorMessageSent = false;
+	
 
-	public MineLevelBlockListData( int currentMineLevel, Mine mine, Random random ) {
+	public MineLevelBlockListData( int currentMineLevel, int maxMineLevel, Mine mine, Random random ) {
 		super();
 		
 		this.currentMineLevel = currentMineLevel;
+		this.maxMineLevel = maxMineLevel;
+		
 		this.mine = mine;
 		
 		this.random = random;
@@ -42,6 +52,8 @@ public class MineLevelBlockListData
 		selectedChance = 0d;
 		airChance = 0d;
 		
+		fillerBlock = null;
+		
 		
 		// PrisonBlocks contains the percent chance of spawning:
 		for ( PrisonBlock pBlock : mine.getPrisonBlocks() )
@@ -49,58 +61,68 @@ public class MineLevelBlockListData
 			// First calculate the total percent chance:
 			totalChance += pBlock.getChance();
 			
+			int cExcludeTop = pBlock.getConstraintExcludeTopLayers();
+			int cExcludeBottom = pBlock.getConstraintExcludeBottomLayers();
+			
+			int cMin = pBlock.getConstraintMin();
+			int cMax = pBlock.getConstraintMax();
+			
+			boolean hasConstraints = cExcludeTop != 0 || cExcludeBottom != 0 ||
+					cMin != 0 || cMax != 0;
+			
+			boolean includeOnThisLevel = 
+					cExcludeTop == 0 && cExcludeBottom == 0 ||
+					
+					(cExcludeTop == 0 || cExcludeTop != 0 && currentMineLevel > cExcludeTop) &&
+					(cExcludeBottom == 0 || cExcludeBottom != 0 && currentMineLevel < cExcludeBottom );
+					
+			
+			
 			// If the block has no constraints, or if the block is within the 
-			// mine constraints, add it to our list.  
+			// mine constraints of top and bottom, then add it to our list.  
+			// If block has exceed max constraint, let it pass through this 
+			// code so it can get the update on the rangeBlockCountHigh.
 			// Check to ensure that the max placement has not been exceeded and if
 			// it has, exclude from this level. Note that past levels may have 
 			// placed more than max.
-			if (
-				( pBlock.getConstraintExcludeTopLayers() == 0 && 
-					pBlock.getConstraintExcludeBottomLayers() == 0 ||
+			if ( includeOnThisLevel ) {
+				
+				
+				// If block has reached it's max, then do not add it's chance or add
+				// add it as a selected block:
+				if ( cMax == 0 || 
+						cMax != 0 && pBlock.getBlockPlacedCount() < cMax) {
 					
-					pBlock.getConstraintExcludeTopLayers() <= currentMineLevel && 
-						(pBlock.getConstraintExcludeBottomLayers() == 0 || 
-						pBlock.getConstraintExcludeBottomLayers() > currentMineLevel) )
+					// Sum the selected blocks:
+					selectedChance += pBlock.getChance();
 					
-					) {
+					// Add the selected blocks to our list:
+					selectedBlocks.add( pBlock );
+					
+					// Need to find a filler block that has no constraints used:
+					if ( !hasConstraints && 
+							(fillerBlock == null || 
+							 fillerBlock != null && pBlock.getChance() > fillerBlock.getChance() ) ) {
+						fillerBlock = pBlock;
+					}
+					
+				}
 				
-				// Sum the selected blocks:
-				selectedChance += pBlock.getChance();
 				
-				// Add the selected blocks to our list:
-				selectedBlocks.add( pBlock );
-				
-				
-				// If exclude top layers is enabled, then only try to set the 
-				// rangeBlockCountLowLimit once since we need the lowest possible 
-				// value.  The initial value for getRangeBlockCountLowLimit is -1.
-				if ( pBlock.getRangeBlockCountLowLimit() == -1 &&
-						(pBlock.getConstraintExcludeTopLayers() <= 0 ||
-						currentMineLevel > pBlock.getConstraintExcludeTopLayers())
-						) {
+				// Only set the rangeBlockCountLowLimit on the first pass through here.
+				// The initial value for getRangeBlockCountLowLimit is -1.
+				if ( pBlock.getRangeBlockCountLowLimit() == -1 ) {
 					
 					int targetBlockPosition = mine.getMineTargetPrisonBlocks().size();
 					pBlock.setRangeBlockCountLowLimit( targetBlockPosition );
 				}
 				
 				
-				// If exclude bottom layer is enabled, then we need to track every number
-				// until the currentLevel exceeds the getConstraintExcludeBottomLayers value.
+				// Always set getConstraintExcludeBottomLayers value:
 				// If exclude top layers, then do not record for the bottom layers until 
 				// the top layers is cleared.
-				if ( (pBlock.getConstraintExcludeTopLayers() > 0 && 
-						currentMineLevel > pBlock.getConstraintExcludeTopLayers() ||
-						pBlock.getConstraintExcludeTopLayers() == 0) &&
-						
-						(pBlock.getConstraintExcludeBottomLayers() == 0 || 
-						pBlock.getConstraintExcludeBottomLayers() > 0 && 
-						currentMineLevel < pBlock.getConstraintExcludeBottomLayers() )
-						) { 
-					
-					int targetBlockPosition = mine.getMineTargetPrisonBlocks().size();
-					pBlock.setRangeBlockCountHighLimit( targetBlockPosition );
-					
-				}
+				int targetBlockPosition = mine.getMineTargetPrisonBlocks().size();
+				pBlock.setRangeBlockCountHighLimit( targetBlockPosition );
 
 			}
 			
@@ -124,32 +146,64 @@ public class MineLevelBlockListData
 	
 	
 	/**
-	 * <p>For each block, run this to ensure all selected blocks that have a specified 
-	 * exclusion from the lower levels of the mine, that the rangeBlockCountHighLimit is
-	 * properly set.
+	 * <p>For each block, need to update the rangeBlockCountHighLimit, even if the
+	 * block has reached it's max constraint.  This is not tracking what was the
+	 * last block that was placed, but it's tracking what is the max range of
+	 * the targetBlocks collection (`mine.getMineTargetPrisonBlocks()`) in which 
+	 * this block can be placed while honoring the constraints exclude from 
+	 * top and exclude from bottom.
 	 * </p>
 	 */
 	public void checkSelectedBlockExcludeFromBottomLayers() {
 		
 		for ( PrisonBlock pBlock : selectedBlocks )
 		{
-			// If exclude bottom layer is enabled, then we need to track every number
-			// until the currentLevel exceeds the getConstraintExcludeBottomLayers value.
-			// If exclude top layers, then do not record for the bottom layers until 
-			// the top layers is cleared.
-			if ( (pBlock.getConstraintExcludeTopLayers() > 0 && 
-					currentMineLevel > pBlock.getConstraintExcludeTopLayers() ||
-					pBlock.getConstraintExcludeTopLayers() == 0) &&
+			int cExcludeTop = pBlock.getConstraintExcludeTopLayers();
+			int cExcludeBottom = pBlock.getConstraintExcludeBottomLayers();
+			
+//			int cMin = pBlock.getConstraintMin();
+//			int cMax = pBlock.getConstraintMax();
+			
+//			boolean hasConstraints = cExcludeTop != 0 || cExcludeBottom != 0 ||
+//					cMin != 0 || cMax != 0;
+			
+			boolean includeOnThisLevel = 
+					cExcludeTop == 0 && cExcludeBottom == 0 ||
 					
-					(pBlock.getConstraintExcludeBottomLayers() == 0 ||
-					pBlock.getConstraintExcludeBottomLayers() > 0 && 
-					pBlock.getConstraintExcludeBottomLayers() < currentMineLevel)
-					) { 
+					(cExcludeTop == 0 || cExcludeTop != 0 && currentMineLevel > cExcludeTop) &&
+					(cExcludeBottom == 0 || cExcludeBottom != 0 && currentMineLevel < cExcludeBottom );
+					
+			
+			
+			// If the block has no constraints, or if the block is within the 
+			// mine constraints of top and bottom, then add it to our list.  
+			// If block has exceed max constraint, let it pass through this 
+			// code so it can get the update on the rangeBlockCountHigh.
+			// Check to ensure that the max placement has not been exceeded and if
+			// it has, exclude from this level. Note that past levels may have 
+			// placed more than max.
+			if ( includeOnThisLevel ) {
 				
 				int targetBlockPosition = mine.getMineTargetPrisonBlocks().size();
 				pBlock.setRangeBlockCountHighLimit( targetBlockPosition );
-				
+
 			}
+			
+//			// If exclude bottom layer is enabled, then we need to track every number
+//			// until the currentLevel exceeds the getConstraintExcludeBottomLayers value.
+//			// If exclude top layers, then do not record for the bottom layers until 
+//			// the top layers is cleared.
+//			if ( (pBlock.getConstraintExcludeTopLayers() > 0 && 
+//					currentMineLevel > pBlock.getConstraintExcludeTopLayers() ||
+//					pBlock.getConstraintExcludeTopLayers() == 0) &&
+//					
+//					(pBlock.getConstraintExcludeBottomLayers() == 0 ||
+//					pBlock.getConstraintExcludeBottomLayers() > 0 && 
+//					pBlock.getConstraintExcludeBottomLayers() < currentMineLevel)
+//					) { 
+//				
+//				
+//			}
 
 		}
 	}
@@ -165,11 +219,14 @@ public class MineLevelBlockListData
 		
 		for ( PrisonBlock block : selectedBlocks ) {
 			
+			// NOTE: do not have use this field anymore:
+//			block.isIncludeInLayerCalculations();
+			
 			// If chance falls on this block, then select it as long as it has not
 			// exceed the max count for this block if the max constraint is enabled.
 			// If the block's constraint max is reached, then isIncludedInLayerCalculation will 
 			// prevent more of them from being added to the mine.
-			if ( block.isIncludeInLayerCalculations() && chance <= block.getChance() ) {
+			if ( chance <= block.getChance() ) {
 				
 				// If this block is chosen and it was not skipped, then use this block and exit.
 				// Otherwise the chance will be recalculated and tried again to find a valid block,
@@ -190,19 +247,111 @@ public class MineLevelBlockListData
 				selected.getConstraintMax() > 0 &&
 				(selected.getBlockPlacedCount() + 1) >= selected.getConstraintMax() ) {
 			
-			selected.setIncludeInLayerCalculations( false );
+//			selected.setIncludeInLayerCalculations( false );
 			
 			selectedBlocks.remove(selected);
 			
 			selectedChance -= selected.getChance();
 		}
 		
+		// if selected == null, then the block feel through the cracks because
+		// if the mine did not have a full 100% chance of all blocks combined, 
+		// then an AIR block was added to the selectedBlocks collection when 
+		// starting to process this level.  So if selected is null, then something
+		// went wrong... assign it the filler block.
+		// If all blocks have constraints, the the filler block will be null so
+		// then assign it an AIR block.
 		if ( chance == 0d && selected == null ) {
-			selected = PrisonBlock.AIR.clone();
+			if ( fillerBlock != null ) {
+				selected = fillerBlock;
+			}
+			else {
+				selected = PrisonBlock.AIR.clone();
+				
+				if ( !errorMessageSent ) {
+					
+					String msg = String.format( 
+							"Error: generateBlockListAsync() selectBlock: "
+							+ "Mine: %s  Layer: %d : All blocks "
+							+ "have constraints so could not backfill a void with a block "
+							+ "so using AIR. Add a non-constrained block to the mine to "
+							+ "prevent air blocks from spawning in this mine when a valid "
+							+ "block cannot be choosen.  This is not a bug, but it's an "
+							+ "issue with base-2 being coverted to base-10 and the "
+							+ "resulting random "
+							+ "generated number not falling on any valid blocks. ",
+							getMine().getName(), getCurrentMineLevel()
+							);
+					Output.get().logError( msg );
+					errorMessageSent = true;
+				}
+			}
 		}
 		
 		return selected;
 	}
-	
+
+	public int getCurrentMineLevel() {
+		return currentMineLevel;
+	}
+	public void setCurrentMineLevel(int currentMineLevel) {
+		this.currentMineLevel = currentMineLevel;
+	}
+
+	public int getMaxMineLevel() {
+		return maxMineLevel;
+	}
+	public void setMaxMineLevel(int maxMineLevel) {
+		this.maxMineLevel = maxMineLevel;
+	}
+
+	public Mine getMine() {
+		return mine;
+	}
+	public void setMine(Mine mine) {
+		this.mine = mine;
+	}
+
+	public Random getRandom() {
+		return random;
+	}
+	public void setRandom(Random random) {
+		this.random = random;
+	}
+
+	public List<PrisonBlock> getSelectedBlocks() {
+		return selectedBlocks;
+	}
+	public void setSelectedBlocks(List<PrisonBlock> selectedBlocks) {
+		this.selectedBlocks = selectedBlocks;
+	}
+
+	public PrisonBlock getFillerBlock() {
+		return fillerBlock;
+	}
+	public void setFillerBlock(PrisonBlock fillerBlock) {
+		this.fillerBlock = fillerBlock;
+	}
+
+	public double getTotalChance() {
+		return totalChance;
+	}
+	public void setTotalChance(double totalChance) {
+		this.totalChance = totalChance;
+	}
+
+	public double getSelectedChance() {
+		return selectedChance;
+	}
+	public void setSelectedChance(double selectedChance) {
+		this.selectedChance = selectedChance;
+	}
+
+	public double getAirChance() {
+		return airChance;
+	}
+	public void setAirChance(double airChance) {
+		this.airChance = airChance;
+	}
 	
 }

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineLevelBlockListData.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineLevelBlockListData.java
@@ -38,6 +38,9 @@ public class MineLevelBlockListData
 	
 	private void initialize() {
 		
+		totalChance = 0d;
+		selectedChance = 0d;
+		airChance = 0d;
 		
 		
 		// PrisonBlocks contains the percent chance of spawning:
@@ -174,12 +177,14 @@ public class MineLevelBlockListData
 				selected = block;
 				
 				break;
-			} else {
+			} 
+			else {
 				chance -= block.getChance();
 			}
 		}
 		
-		// If block reaches it's max amount, remove it from the block list.
+		// If block reaches it's max amount, remove it from the block list so it will not 
+		// be selected again. If max is reached, then this block is the max number allowed.
 		// Note that the block has not been incremented yet, so add one to the placement count
 		if ( selected != null && 
 				selected.getConstraintMax() > 0 &&
@@ -187,9 +192,13 @@ public class MineLevelBlockListData
 			
 			selected.setIncludeInLayerCalculations( false );
 			
-//			selectedBlocks.remove(selected);
+			selectedBlocks.remove(selected);
 			
-//			selectedChance -= selected.getChance();
+			selectedChance -= selected.getChance();
+		}
+		
+		if ( chance == 0d && selected == null ) {
+			selected = PrisonBlock.AIR.clone();
 		}
 		
 		return selected;

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
@@ -28,6 +28,7 @@ import tech.mcprison.prison.mines.features.MineTracerBuilder;
 import tech.mcprison.prison.mines.tasks.MinePagedResetAsyncTask;
 import tech.mcprison.prison.mines.tasks.MineTeleportTask;
 import tech.mcprison.prison.output.Output;
+import tech.mcprison.prison.output.Output.DebugTarget;
 import tech.mcprison.prison.tasks.PrisonCommandTaskData;
 import tech.mcprison.prison.tasks.PrisonCommandTasks;
 import tech.mcprison.prison.tasks.PrisonRunnable;
@@ -640,7 +641,7 @@ public abstract class MineReset
 		constraintsApplyMin();
 		
 		
-		if ( Output.get().isDebug() ) {
+		if ( Output.get().isDebug() && Output.get().isSelectiveTarget( DebugTarget.blockConstraints ) ) {
 			
 	    	DecimalFormat dFmt = Prison.get().getDecimalFormatDouble();
 	    	DecimalFormat iFmt = Prison.get().getDecimalFormatInt();

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
@@ -476,7 +476,9 @@ public abstract class MineReset
     
     protected abstract void broadcastPendingResetMessageToAllPlayersWithRadius(MineJob mineJob);
     
-  
+    protected abstract void broadcastSkipResetMessageToAllPlayersWithRadius();
+
+    
 	
 	public int getPlayerCount() {
 		int count = 0;
@@ -1608,6 +1610,9 @@ public abstract class MineReset
 				
 				if ( getSkipResetBypassCount() < getSkipResetBypassLimit() ) {
 					// Skip Reset!!
+					
+					broadcastSkipResetMessageToAllPlayersWithRadius();
+					
 					return;
 				}
 				

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
@@ -564,7 +564,6 @@ public abstract class MineReset
 		World world = worldOptional.get();
 		
 		int airCount = 0;
-		int currentLevel = 0;
 		
 		
 		int yMin = getBounds().getyBlockMin();
@@ -575,6 +574,10 @@ public abstract class MineReset
 		
 		int zMin = getBounds().getzBlockMin();
 		int zMax = getBounds().getzBlockMax();
+
+		
+		int currentLevel = 0;
+		int maxLevels = yMax - yMin + 1;
 		
 		
 		// The reset takes place first with the top-most layer since most mines may have
@@ -585,7 +588,7 @@ public abstract class MineReset
 			
 			// This is used to select the correct block list for the given mine level:
 			MineLevelBlockListData mineLevelBlockList = 
-							new MineLevelBlockListData( currentLevel, (Mine) this, random );
+							new MineLevelBlockListData( currentLevel, maxLevels, (Mine) this, random );
 			
 			
 			for (int x = xMin; x <= xMax; x++) {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineReset.java
@@ -3,9 +3,12 @@ package tech.mcprison.prison.mines.data;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 import tech.mcprison.prison.Prison;
 import tech.mcprison.prison.internal.Player;
@@ -890,6 +893,105 @@ public abstract class MineReset
 //    	
 //    	
 //    }
+    
+    
+    
+    public List<String> getTargetBlockStatsPerLevel() {
+    	List<String> layers = new ArrayList<>();
+    	
+    	int blocksPerLayer = getBounds().getBlockCountPerLayer();
+    	//int totalLayers = getBounds().getTotalLayers();
+    	
+    	// BlockName = BlockLetter
+    	TreeMap<String,String> translator = new TreeMap<>();
+    	TreeMap<String,Integer> map = new TreeMap<>();
+    	
+    	// Build translations:
+    	char blk = 'A';
+    	double chance = 0;
+    	boolean hasAir = false;
+    	
+    	// First add all the blocks with an empty String as the value:
+    	for (PrisonBlock b : getPrisonBlocks() ) {
+			chance += b.getChance();
+			translator.put( b.getBlockName(), "" );
+			if ( b.isAir() ) {
+				hasAir = true;
+			}
+		}
+    	if ( !hasAir && chance < 100.0d ) {
+    		translator.put( PrisonBlock.AIR.getBlockName(), "" );
+    	}
+    	// Now that they are in order, assign the alphabetical names:
+    	Set<String> tkeys = translator.keySet();
+    	for (String tKey : tkeys) {
+    		translator.put( tKey, Character.toString( blk++ ) );
+		}
+
+    	
+    	for ( int i = 0; i < getMineTargetPrisonBlocks().size(); i++ ) {
+    		MineTargetPrisonBlock tBlock = getMineTargetPrisonBlocks().get(i);
+    		int level = (int) ((i / (double) blocksPerLayer) + 1);
+    		
+    		String keyPrime = tBlock.getPrisonBlock() == null ? 
+    					PrisonBlock.AIR.getBlockName() : 
+    					tBlock.getPrisonBlock().getBlockName();
+    		
+    		String key = translator.get(keyPrime);
+
+    		if ( !map.containsKey(key) ) {
+    			map.put( key, 1 );
+    		}
+    		else {
+    			map.put( key, 1 + map.get(key) );
+    		}
+    		
+    		// if last block of the layer:
+    		if ( (int) (((i + 1) / (double) blocksPerLayer) + 1) > level ) {
+    			StringBuilder sb = new StringBuilder();
+    			
+    			sb.append( "Layer " ).append( level ).append( " : " );
+    			
+    			TreeSet<String> keys = new TreeSet<>( map.keySet() );
+    			for ( String k : keys ) {
+//    				for ( Entry<String, String> eSet : translator.entrySet()) {
+//    					if ( eSet.getValue().equalsIgnoreCase(k) ) {
+//    						
+//    						String blockName = eSet.getKey();
+//    						sb.append( blockName ).append( ":" ).append( map.get(k) ).append( " " );
+//
+//    						break;
+//    					}
+//    				}
+    				sb.append( k ).append( ":" ).append( map.get(k) ).append( " " );
+				}
+    			
+    			layers.add( sb.toString() );
+    			
+    			map.clear();
+    		}
+    	}
+    	
+    	
+    	{
+    		// print the legend:
+    		StringBuilder sb = new StringBuilder();
+    		
+    		sb.append( "Legend: " );
+    		
+    		for ( Entry<String, String> eSet : translator.entrySet()) {
+    			String blockName = eSet.getKey();
+    			sb.append( eSet.getValue() ).append( ":" ).append( blockName ).append( " " );
+    		}
+    		
+    		layers.add( sb.toString() );
+    		
+    	}
+    	
+    	
+    	return layers;
+    }
+    
     
     public void asynchronouslyResetSetup() {
     	

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineScheduler.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineScheduler.java
@@ -496,7 +496,8 @@ public abstract class MineScheduler
 			// Submit currentJob using delay in the job. Must be a one time run, no repeats.
 			int taskId = PrisonTaskSubmitter.runTaskLater(this, ticksToWait);
 			setTaskId( taskId );
-		} else {
+		} 
+		else {
 			Output.get().logError("Mine " + getName() +
 					" failed to resubmit itself so it will not auto reset. Manually reset " +
 					"this mine to re-enable the auto reset.");
@@ -752,11 +753,14 @@ public abstract class MineScheduler
 		
 		if ( !isVirtual() && getMineStateMutex().isMinable() ) {
 			
+			int totalBlocks = getBounds().getTotalBlockCount();
+			int remaining = getRemainingBlockCount();
+			double threshold = getResetThresholdPercent() == 0 ? 0 :
+							totalBlocks * getResetThresholdPercent() / 100.0d;
+			
 			if (
-					getRemainingBlockCount() <= 0 && !isZeroBlockResetDisabled() || 
-					getResetThresholdPercent() > 0 && 
-					getRemainingBlockCount() < (getBounds().getTotalBlockCount() * 
-							getResetThresholdPercent() / 100.0d)
+					remaining <= 0 && !isZeroBlockResetDisabled() || 
+					remaining <= threshold
 					) {
 				
 				// submit a manual reset since the mine is empty:
@@ -816,9 +820,9 @@ public abstract class MineScheduler
 		
 		if ( !getMineStateMutex().isMinable() && 
 				getMineResetStartTimestamp() != -1 && 
-				System.currentTimeMillis() - getMineResetStartTimestamp() > 4 * 60000 ) {
+				System.currentTimeMillis() - getMineResetStartTimestamp() > 3 * 60000 ) {
 			
-			// Mine reset was trying to run for more than 4 minutes... so it's locked out and failed?
+			// Mine reset was trying to run for more than 3 minutes... so it's locked out and failed?
 			
 			// reset mutex and allow the rest to be forced:
 			getMineStateMutex().setMineStateResetFinishedForced();

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineScheduler.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineScheduler.java
@@ -816,7 +816,7 @@ public abstract class MineScheduler
 		
 		if ( !getMineStateMutex().isMinable() && 
 				getMineResetStartTimestamp() != -1 && 
-				getMineResetStartTimestamp() - System.currentTimeMillis() > 4 * 60000 ) {
+				System.currentTimeMillis() - getMineResetStartTimestamp() > 4 * 60000 ) {
 			
 			// Mine reset was trying to run for more than 4 minutes... so it's locked out and failed?
 			
@@ -872,29 +872,31 @@ public abstract class MineScheduler
 //				}
 //				
 //			}
+			
+			
+			
+			// cancel existing job:
+			if ( getTaskId() != null ) {
+				PrisonTaskSubmitter.cancelTask( getTaskId() );
+			}
+			
+			// Clear jobStack and set currentJob to run the RESET with zero delay:
+			getJobStack().clear();
+			
+			MineJobAction action = MineJobAction.RESET_ASYNC; // : MineJobAction.RESET_SYNC;
+			
+			MineJob mineJob = new MineJob( action, delayActionSec, 0, resetType );
+			mineJob.setResetType( resetType );
+			mineJob.setResetActions( resetActions );
+			
+			setCurrentJob( mineJob );
+			
+			// Force reset even if skip is enabled:
+			
+			// Submit to run:
+			submitTask();
 		}
 		
-		
-		// cancel existing job:
-		if ( getTaskId() != null ) {
-			PrisonTaskSubmitter.cancelTask( getTaskId() );
-		}
-		
-		// Clear jobStack and set currentJob to run the RESET with zero delay:
-		getJobStack().clear();
-		
-		MineJobAction action = MineJobAction.RESET_ASYNC; // : MineJobAction.RESET_SYNC;
-		
-		MineJob mineJob = new MineJob( action, delayActionSec, 0, resetType );
-		mineJob.setResetType( resetType );
-		mineJob.setResetActions( resetActions );
-		
-		setCurrentJob( mineJob );
-    	
-		// Force reset even if skip is enabled:
-		
-		// Submit to run:
-		submitTask();
 	}
 
 	public List<MineJob> getJobWorkflow()

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineScheduler.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineScheduler.java
@@ -398,8 +398,10 @@ public abstract class MineScheduler
 		    		resetTask.submitTaskAsync();
 		    		
 //					resetAsynchonously();
-				} else {
+				} 
+				else {
 					incrementSkipResetBypassCount();
+					broadcastSkipResetMessageToAllPlayersWithRadius();
 				}
 				
 				break;

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineTasks.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/MineTasks.java
@@ -299,6 +299,57 @@ public abstract class MineTasks
 //        setStatsMessageBroadcastTimeMS( stop - start );
     }
     
+	
+	@Override
+	protected void broadcastSkipResetMessageToAllPlayersWithRadius() {
+//    	long start = System.currentTimeMillis();
+		
+		if ( isVirtual() || getResetTime() <= 0 ) {
+			// ignore:
+		}
+		else if ( PrisonMines.getInstance().getMinesMessages()
+				.getLocalizable("skip_reset_message").localize().trim().length() == 0 ) {
+			
+			// NOTE: The mine_skip_reset_message is blank, so do not broadcast it...
+		}
+		else 
+			if ( getNotificationMode() != MineNotificationMode.disabled ) {
+				World world = getBounds().getCenter().getWorld();
+				
+				if ( world != null ) {
+					List<Player> players = (world.getPlayers() != null ? world.getPlayers() : 
+						Prison.get().getPlatform().getOnlinePlayers());
+					for (Player player : players) {
+						
+						// Check for either mode: Within the mine, or by radius from mines center:
+						if ( getNotificationMode() == MineNotificationMode.within && 
+								getBounds().withinIncludeTopBottomOfMine(player.getLocation() ) ||
+								getNotificationMode() == MineNotificationMode.radius && 
+								getBounds().within(player.getLocation(), getNotificationRadius()) ) {
+							
+							if ( !isUseNotificationPermission() ||
+									isUseNotificationPermission() && 
+									player.hasPermission( getMineNotificationPermissionName() ) ) {
+								
+								
+								PrisonMines.getInstance().getMinesMessages()
+								.getLocalizable("skip_reset_message").withReplacements( getTag() )
+								.sendTo(player);
+								
+//    						player.sendMessage( "The mine " + getName() + " has just reset." );
+							}
+						}
+					}
+					
+				}
+				
+			}
+		
+//        long stop = System.currentTimeMillis();
+		
+//        setStatsMessageBroadcastTimeMS( stop - start );
+	}
+	
     @Override
     protected void broadcastPendingResetMessageToAllPlayersWithRadius(MineJob mineJob) {
     	

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/data/OnStartupRefreshBlockBreakCountSyncTask.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/data/OnStartupRefreshBlockBreakCountSyncTask.java
@@ -69,9 +69,9 @@ public class OnStartupRefreshBlockBreakCountSyncTask
 			int start = position;
 			for (int i = start; i < locations.size(); i++ ) {
 				
-				Location targetBlock = locations.get( i );
+				Location targetLocation = locations.get( i );
 				
-				mine.refreshAirCountSyncTaskSetLocation( targetBlock, this );
+				mine.refreshAirCountSyncTaskSetLocation( targetLocation, this );
 				position++;
 		
 				if ( (i - start) % 500 == 0 ) {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/features/MineLinerBuilder.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/features/MineLinerBuilder.java
@@ -175,7 +175,8 @@ public class MineLinerBuilder {
 		
 	}
 	
-	public MineLinerBuilder( Mine mine, Edges edge, LinerPatterns pattern, boolean isForced ) {
+	public MineLinerBuilder( Mine mine, Edges edge, LinerPatterns pattern,
+					boolean isForced, boolean useTracer ) {
 		super();
 		
 		this.pattern3d = new ArrayList<>();
@@ -193,10 +194,18 @@ public class MineLinerBuilder {
 		this.isForced = isForced;
 		
 		if ( pattern != null ) {
-			mine.enableTracer( MineResetType.clear );
+			if ( useTracer ) {
+				
+				mine.enableTracer( MineResetType.clear );
+			}
 			
 			generatePattern( edge );
 		}
+	}
+	
+	public MineLinerBuilder( Mine mine, Edges edge, LinerPatterns pattern, boolean isForced ) {
+		this( mine, edge, pattern, isForced, true );
+
 	}
 	
 	private void generatePattern( Edges edge ) {

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/managers/MineManager.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/managers/MineManager.java
@@ -303,7 +303,12 @@ public class MineManager
      */
     private boolean add(Mine mine, boolean save, int offsetTimingMs ) {
     	boolean results = false;
-        if (!getMines().contains(mine)){
+    	
+    	// not add if it already exists, or if the mine is null or does not have a valid name:
+        if ( mine != null &&  mine.getName() != null && 
+        		mine.getName().trim().length() > 0 && 
+        		!getMines().contains(mine)) {
+        	
         	if ( save ) {
         		saveMine( mine );
         	}

--- a/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MinePagedResetAsyncTask.java
+++ b/prison-mines/src/main/java/tech/mcprison/prison/mines/tasks/MinePagedResetAsyncTask.java
@@ -194,8 +194,15 @@ public class MinePagedResetAsyncTask
 			}
 
 			// Isolate the sub-list from the main targetBlocks list:
+			List<MineTargetPrisonBlock> subList = new ArrayList<>();
+			
+			for ( int i = position; i < endIndex; i++ ) {
+				subList.add( targetBlocks.get( i ) );
+			}
+//										targetBlocks.subList( position, endIndex ) );
+			
 			List<MineTargetPrisonBlock> tBlocks = new ArrayList<>();
-			for (MineTargetPrisonBlock mtpb : targetBlocks.subList( position, endIndex )) {
+			for (MineTargetPrisonBlock mtpb : subList ) {
 				tBlocks.add(mtpb);
 			}		
 			

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/LadderCommands.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/LadderCommands.java
@@ -474,7 +474,8 @@ public class LadderCommands
 			@Arg( name = "ladderName" ) String ladderName,
 			@Arg( name = "applyRankCostMultiplier", def = "apply", 
 				description = "Applies or disables the ranks on this ladder "
-					+ "from applying the rank multiplier to the rank cost for players."
+					+ "from applying the rank multiplier to the rank cost for players. "
+					+ "Use a value of 'apply' or 'true'; anything else is treated as 'false'."
 					) 
 			String applyRankCostMultiplier )
 	{
@@ -487,7 +488,8 @@ public class LadderCommands
 		}
 		
 		boolean applyRCM = applyRankCostMultiplier != null && 
-				applyRankCostMultiplier.equalsIgnoreCase( "apply" );
+				(applyRankCostMultiplier.equalsIgnoreCase( "apply" ) || 
+						applyRankCostMultiplier.equalsIgnoreCase( "true" ) );
 		
 		boolean applyRCMOld = ladder.isApplyRankCostMultiplierToLadder();
 		

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RankUpCommand.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RankUpCommand.java
@@ -768,34 +768,43 @@ public class RankUpCommand
         UUID playerUuid = player.getUUID();
         
 		ladder = confirmLadder( sender, ladder );
+		if ( ladder == null ) {
+			return;
+		}
 
 		RankPlayerFactory rankPlayerFactory = new RankPlayerFactory();
 		
         RankPlayer rankPlayer = getRankPlayer( sender, playerUuid, player.getName() );
         PlayerRank playerRank = rankPlayerFactory.getRank( rankPlayer, ladder );
         
-        if ( playerRank != null ) {
+        if ( rankPlayer != null && playerRank != null ) {
         	
         	Rank pRank = playerRank.getRank();
+        	if ( pRank == null ) {
+        		sender.sendMessage( "Promote: There was an error trying to access the "
+        				+ "current rank of the player. Try viewing the player's "
+        				+ "details: '/ranks player help'.");
+        		return;
+        	}
         	
         	// Get currency if it exists, otherwise it will be null if the Rank has no currency:
-        	String currency = rankPlayer == null || pRank == null ? null : pRank.getCurrency();
+        	String currency = pRank.getCurrency();
         	
-        	if ( ladder != null && rankPlayer != null ) {
-        		
-        		List<PrisonCommandTaskData> cmdTasks = new ArrayList<>();
-        		
-        		RankupResults results = new RankUtil().promotePlayer(player, rankPlayer, ladder, 
-        				player.getName(), sender.getName(), pForceCharge, cmdTasks );
-
-        		// submit cmdTasks...
-    			submitCmdTasks( player, cmdTasks );
-        		
-        		processResults( sender, player.getName(), results, null, ladder, currency, null );
-        	}
+        	List<PrisonCommandTaskData> cmdTasks = new ArrayList<>();
+        	
+        	RankupResults results = new RankUtil().promotePlayer(player, rankPlayer, ladder, 
+        			player.getName(), sender.getName(), pForceCharge, cmdTasks );
+        	
+        	// submit cmdTasks...
+        	submitCmdTasks( player, cmdTasks );
+        	
+        	processResults( sender, player.getName(), results, null, ladder, currency, null );
+        	
         }
         else {
         	// Message: Player is not on the ladder
+        	sender.sendMessage( "Promote: Player is not on the specified ladder. "
+        			+ "Try using '/ranks set rank' to add them.");
         }
     }
 
@@ -842,28 +851,34 @@ public class RankUpCommand
         RankPlayer rankPlayer = getRankPlayer( sender, playerUuid, player.getName() );
         PlayerRank playerRank = rankPlayerFactory.getRank( rankPlayer, ladder );
         
-        if ( playerRank != null ) {
+        if ( rankPlayer != null && playerRank != null ) {
         	
         	Rank pRank = playerRank.getRank();
+        	if ( pRank == null ) {
+        		sender.sendMessage( "Demote: There was an error trying to access the "
+        				+ "current rank of the player. Try viewing the player's "
+        				+ "details: '/ranks player help'.");
+        		return;
+        	}
         	
         	// Get currency if it exists, otherwise it will be null if the Rank has no currency:
-        	String currency = rankPlayer == null || pRank == null ? null : pRank.getCurrency();
+        	String currency = pRank.getCurrency();
         	
-        	if ( ladder != null && rankPlayer != null ) {
-        		
-        		List<PrisonCommandTaskData> cmdTasks = new ArrayList<>();
-        		
-        		RankupResults results = new RankUtil().demotePlayer(player, rankPlayer, ladder, 
-        				player.getName(), sender.getName(), pForceCharge, cmdTasks );
-        		
-        		// submit cmdTasks
-    			submitCmdTasks( player, cmdTasks );
-        		
-        		processResults( sender, player.getName(), results, null, ladder, currency, null );
-        	}
+        	List<PrisonCommandTaskData> cmdTasks = new ArrayList<>();
+        	
+        	RankupResults results = new RankUtil().demotePlayer(player, rankPlayer, ladder, 
+        			player.getName(), sender.getName(), pForceCharge, cmdTasks );
+        	
+        	// submit cmdTasks
+        	submitCmdTasks( player, cmdTasks );
+        	
+        	processResults( sender, player.getName(), results, null, ladder, currency, null );
+        	
         }
         else {
         	// Message: Player is not on the ladder
+        	sender.sendMessage( "Demote: Player is not on the specified ladder. "
+        			+ "Try using '/ranks set rank' to add them.");
         }
     }
 

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RankUpCommandMessages.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RankUpCommandMessages.java
@@ -25,11 +25,12 @@ public class RankUpCommandMessages
 	}
 
 	
-	protected void rankupMaxNoPermissionMsg( CommandSender sender, String permission ) {
+	protected void rankupMaxNoPermissionMsg( CommandSender sender, String permission, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__no_permission" )
 				.withReplacements( permission.toLowerCase() )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
 	protected String rankupCannotRunFromConsoleMsg() {
@@ -85,50 +86,65 @@ public class RankUpCommandMessages
 		.sendTo( sender );
 	}
 	
-	protected void rankupNotAtLastRankMsg( CommandSender sender ) {
+	protected void rankupNotAtLastRankMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__not_at_last_rank" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void rankupAtLastRankMsg( CommandSender sender ) {
+	protected void rankupAtLastRankMsg( CommandSender sender, 
+			RankPlayer rPlayer  ) {
 		PrisonRanks.getInstance().getRanksMessages()
 		.getLocalizable( "ranks_rankup__at_last_rank" )
-		.sendTo( sender );
+		.sendTo( sender, rPlayer );
 	}
 	
-	protected void rankupNotAbleToPrestigeMsg( CommandSender sender ) {
+	protected void rankupNotAbleToPrestigeMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__not_able_to_prestige" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void rankupNotAbleToResetRankMsg( CommandSender sender ) {
+	protected void rankupNotAbleToResetRankMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__not_able_to_reset_rank" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
 	
 	
-	protected void prestigePlayerBalanceSetToZeroMsg( CommandSender sender ) {
+	protected void prestigePlayerBalanceSetToZeroMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__balance_set_to_zero" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void prestigePlayerSucessfulMsg( CommandSender sender, String tag ) {
+	protected void prestigePlayerSucessfulMsg( CommandSender sender, String tag, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__prestige_successful" )
 				.withReplacements( tag )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void prestigePlayerFailureMsg( CommandSender sender, String tag ) {
+	protected void prestigePlayerSucessfulBroadcastMsg( CommandSender sender, String tag, 
+			RankPlayer rPlayer ) {
+		PrisonRanks.getInstance().getRanksMessages()
+		.getLocalizable( "ranks_rankup__prestige_successful_broadcast" )
+		.withReplacements( tag )
+		.sendTo( sender, rPlayer );
+	}
+	
+	protected void prestigePlayerFailureMsg( CommandSender sender, String tag, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__prestige_failure" )
 				.withReplacements( tag )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 
 	protected String prestigeConfirmationGUIMsg( CommandSender sender, 
@@ -146,34 +162,46 @@ public class RankUpCommandMessages
 		if ( tag == null ) {
 			tag = targetRank.getRank().getName();
 		}
-		sb.append( rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_1" )
-				.withReplacements( tag )
-					.localize().replace(" ", "_") ).append( " " );
+		sb.append( 
+				rPlayer.convertStringPlaceholders( 
+					rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_1" )
+					.withReplacements( tag )
+						.localize().replace(" ", "_") )).append( " " );
 		
-		sb.append( rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_2" )
-				.withReplacements( 
-						dFmt.format( targetRank.getRankCost()) )
-				.localize().replace(" ", "_") ).append( " " );
+		sb.append( 
+				rPlayer.convertStringPlaceholders( 
+						rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_2" )
+					.withReplacements( 
+							dFmt.format( targetRank.getRankCost()) )
+					.localize().replace(" ", "_") )).append( " " );
 		
-		sb.append( rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_3" )
-				.withReplacements( 
-						dFmt.format( balance),
-						currency == null || currency.trim().length() == 0 ? 
-								"" : " " + currency )
-				.localize().replace(" ", "_") ).append( " " );
+		sb.append( 
+				rPlayer.convertStringPlaceholders( 
+						rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_3" )
+					.withReplacements( 
+							dFmt.format( balance),
+							currency == null || currency.trim().length() == 0 ? 
+									"" : " " + currency )
+					.localize().replace(" ", "_") )).append( " " );
 
 		if ( isResetDefaultLadder ) {
-			sb.append( rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_4" )
-					.localize().replace(" ", "_") ).append( " " );
+			sb.append( 
+					rPlayer.convertStringPlaceholders( 
+							rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_4" )
+							.localize().replace(" ", "_") )).append( " " );
 		}
 
 		if ( isConfirmationEnabled ) {
-			sb.append( rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_5" )
-					.localize().replace(" ", "_") ).append( " " );
+			sb.append( 
+					rPlayer.convertStringPlaceholders( 
+							rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_5" )
+							.localize().replace(" ", "_") )).append( " " );
 		}
 
-		sb.append( rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_7" )
-				.localize().replace(" ", "_") );
+		sb.append( 
+				rPlayer.convertStringPlaceholders( 
+						rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_7" )
+						.localize().replace(" ", "_") ));
 		
 		return sb.toString();
 	}
@@ -196,38 +224,38 @@ public class RankUpCommandMessages
 		}
 		rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_1" )
 			.withReplacements( tag )
-			.sendTo( sender );
+			.sendTo( sender, rPlayer );
 		
 		
 		rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_2" )
 			.withReplacements( 
 				dFmt.format( targetRank.getRankCost()) )
-			.sendTo( sender );
+			.sendTo( sender, rPlayer );
 		
 		rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_3" )
 		.withReplacements( 
 				dFmt.format( balance),
 				currency == null || currency.trim().length() == 0 ? 
 						"" : " " + currency )
-			.sendTo( sender );
+			.sendTo( sender, rPlayer );
 
 		if ( isResetDefaultLadder ) {
 			rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_4" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 		}
 
 		if ( isResetMoney ) {
 			rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_4" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 		}
 		
 		rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_5" )
-			.sendTo( sender );
+			.sendTo( sender, rPlayer );
 		
 		String playerName = !isPlayer ? rPlayer.getName() + " " : "";
 		rMsg.getLocalizable( "ranks_rankup__confirm_prestige_line_6" )
 			.withReplacements( playerName )
-			.sendTo( sender );
+			.sendTo( sender, rPlayer );
 
 		
 //		ranks_rankup__confirm_prestige_line_1=&3Confirm Prestige: %s
@@ -240,7 +268,8 @@ public class RankUpCommandMessages
 	}
 	
 	protected void ranksRankupPlayerBalanceMsg( CommandSender sender, 
-			double balance, String currency ) {
+			double balance, String currency, 
+			RankPlayer rPlayer ) {
 		DecimalFormat dFmt = Prison.get().getDecimalFormat("#,##0.00");
 
 		LocaleManager rMsg = PrisonRanks.getInstance().getRanksMessages();
@@ -250,7 +279,7 @@ public class RankUpCommandMessages
 				dFmt.format( balance),
 				currency == null || currency.trim().length() == 0 ? 
 						"" : " " + currency )
-			.sendTo( sender );
+			.sendTo( sender, rPlayer );
 	}
 	
 	protected void ranksPromotePlayerMustBeOnlineMsg( CommandSender sender ) {
@@ -259,31 +288,34 @@ public class RankUpCommandMessages
 				.sendTo( sender );
 	}
 	
-	protected void ranksPromotePlayerInvalidChargeValueMsg( CommandSender sender ) {
+	protected void ranksPromotePlayerInvalidChargeValueMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__invalid_charge_value" )
 				.withReplacements(
 						PromoteForceCharge.no_charge.name(), 
 						PromoteForceCharge.charge_player.name()
 						)
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksDemotePlayerInvalidRefundValueMsg( CommandSender sender ) {
+	protected void ranksDemotePlayerInvalidRefundValueMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__invalid_refund_value" )
 				.withReplacements(
 						PromoteForceCharge.no_charge.name(), 
 						PromoteForceCharge.refund_player.name()
 						)
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksConfirmLadderMsg( CommandSender sender, String ladderName ) {
+	protected void ranksConfirmLadderMsg( CommandSender sender, String ladderName, 
+			RankPlayer rPlayer ) {
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_failure_invalid_ladder" )
 				.withReplacements( ladderName )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
 	
@@ -297,7 +329,10 @@ public class RankUpCommandMessages
 	
 	protected void ranksRankupSuccessMsg( CommandSender sender, String playerName, 
 			RankupResults results, 
-			StringBuilder sbRanks ) {
+			StringBuilder sbRanks
+			 ) {
+		
+		RankPlayer rPlayer = results.getRankPlayer();
 		
 //		PlayerRank tpRank = results.getPlayerRankTarget();
 		Rank tRank = results.getTargetRank();
@@ -333,7 +368,9 @@ public class RankUpCommandMessages
     					
     					sender.getName(), localManager.localize()
     				);           	
-    	Output.get().logInfo( localManagerLog.localize() );
+    	Output.get().logInfo( 
+    			rPlayer.convertStringPlaceholders( 
+    					localManagerLog.localize() ));
 
     	
     	if ( Prison.get().getPlatform().getConfigBooleanFalse( "broadcast-rankups" ) ) {
@@ -348,14 +385,15 @@ public class RankUpCommandMessages
     				(tRank == null ? "" : tRank.getTag() ), 
     				(results.getMessage() != null ? results.getMessage() : "")
     			)
-        		.broadcast();
+        		.broadcast( rPlayer );
     	}
     	else {
-    		localManager.sendTo( sender );
+    		localManager.sendTo( sender, rPlayer );
     	}
 	}
 
-	protected void ranksRankupMaxSuccessMsg( CommandSender sender, StringBuilder ranks ) {
+	protected void ranksRankupMaxSuccessMsg( CommandSender sender, StringBuilder ranks, 
+			RankPlayer rPlayer ) {
 		
     	Localizable localManagerLog = PrisonRanks.getInstance().getRanksMessages()
     			.getLocalizable( "ranks_rankup__log_rank_change" )
@@ -370,12 +408,12 @@ public class RankUpCommandMessages
     	
     	if ( Prison.get().getPlatform().getConfigBooleanFalse( "broadcast-rankups" ) ) {
     		
-    		localManagerLog.broadcast();
+    		localManagerLog.broadcast( rPlayer );
     		
     	}
     	else {
     		
-    		localManagerLog.sendTo( sender );
+    		localManagerLog.sendTo( sender, rPlayer );
     	}
 	}
 	
@@ -384,11 +422,12 @@ public class RankUpCommandMessages
 		
 		PlayerRank tpRank = results.getPlayerRankTarget();
 		
-		ranksRankupCannotAffordMsg( sender, tpRank );
+		ranksRankupCannotAffordMsg( sender, tpRank, results.getRankPlayer() );
 	}
 	
 	protected void ranksRankupCannotAffordMsg( CommandSender sender, 
-			PlayerRank tpRank ) {
+			PlayerRank tpRank, 
+			RankPlayer rPlayer ) {
 			
 		DecimalFormat dFmt = Prison.get().getDecimalFormat("#,##0.00");
     	
@@ -402,7 +441,7 @@ public class RankUpCommandMessages
     				tRank == null || tRank.getCurrency() == null ? "" : 
     					" " +tRank.getCurrency()
 				)
-	    		.sendTo( sender );
+	    		.sendTo( sender, rPlayer );
 	}
 
 	protected void ranksRankupLowestRankMsg( CommandSender sender, String playerName,
@@ -416,7 +455,7 @@ public class RankUpCommandMessages
 				.withReplacements(
 						(playerName == null ? messagYouAre : playerName)
 					)
-				.sendTo( sender );
+				.sendTo( sender, results.getRankPlayer() );
 	}
 	
 	protected void ranksRankupHighestRankMsg( CommandSender sender, String playerName,
@@ -430,107 +469,120 @@ public class RankUpCommandMessages
 				.withReplacements(
 						(playerName == null ? messagYouAre : playerName)
 					)
-				.sendTo( sender );
+				.sendTo( sender, results.getRankPlayer() );
 	}
 	
-	protected void ranksRankupFailureMsg( CommandSender sender ) {
+	protected void ranksRankupFailureMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_failure" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksRankupFailureCouldNotLoadPlayerMsg( CommandSender sender ) {
+	protected void ranksRankupFailureCouldNotLoadPlayerMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 		    	.getLocalizable( "ranks_rankup__rankup_failed_to_load_player" )
-		    	.sendTo( sender );
+		    	.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksRankupFailureCouldNotLoadLadderMsg( CommandSender sender ) {
+	protected void ranksRankupFailureCouldNotLoadLadderMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_failed_to_load_ladder" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksRankupFailureUnableToAssignRankMsg( CommandSender sender ) {
+	protected void ranksRankupFailureUnableToAssignRankMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_failed_to_assign_rank" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksRankupFailureUnableToAssignRankWithRefundMsg( CommandSender sender ) {
+	protected void ranksRankupFailureUnableToAssignRankWithRefundMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 		.getLocalizable( "ranks_rankup__rankup_failed_to_assign_rank_with_refund" )
-		.sendTo( sender );
+		.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksRankupFailureCouldNotSavePlayerFileMsg( CommandSender sender ) {
+	protected void ranksRankupFailureCouldNotSavePlayerFileMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_failed_to_save_player_file" )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksRankupFailureNoRanksMsg( CommandSender sender ) {
+	protected void ranksRankupFailureNoRanksMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_no_ranks" )
-				.sendTo( sender ); 
+				.sendTo( sender, rPlayer ); 
 	}
 	
-	protected void ranksRankupFailureRankDoesNotExistMsg( CommandSender sender, String rank ) {
+	protected void ranksRankupFailureRankDoesNotExistMsg( CommandSender sender, String rank, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_rank_does_not_exist" )
 				.withReplacements( rank )
-				.sendTo( sender ); 
+				.sendTo( sender, rPlayer ); 
 	}
 	
 	protected void ranksRankupFailureRankIsNotInLadderMsg( CommandSender sender, 
-			String rank, String ladder ) {
+			String rank, String ladder, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_rank_is_not_in_ladder" )
 				.withReplacements( rank, ladder )
-				.sendTo( sender ); 
+				.sendTo( sender, rPlayer ); 
 	}
 	
 	protected void ranksRankupFailureCurrencyIsNotSupportedMsg( CommandSender sender, 
-			String currency ) {
+			String currency, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_currency_is_not_supported" )
 				.withReplacements( currency )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
 	protected void ranksRankupFailureLadderRemovedMsg( CommandSender sender, 
-			String ladder ) {
+			String ladder, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_ladder_removed" )
 				.withReplacements( ladder )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
 	protected void ranksRankupFailureRemovingLadderMsg( CommandSender sender, 
-			String ladder ) {
+			String ladder, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 				.getLocalizable( "ranks_rankup__rankup_failure_removing_ladder" )
 				.withReplacements( ladder )
-				.sendTo( sender );
+				.sendTo( sender, rPlayer );
 	}
 	
-	protected void ranksRankupFailureInProgressMsg( CommandSender sender ) {
+	protected void ranksRankupFailureInProgressMsg( CommandSender sender, 
+			RankPlayer rPlayer ) {
 		
 		PrisonRanks.getInstance().getRanksMessages()
 			.getLocalizable( "ranks_rankup__rankup_in_progress_failure" )
-			.sendTo( sender );
+			.sendTo( sender, rPlayer );
 	}
 	
 	

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
@@ -2268,6 +2268,7 @@ public class RanksCommands
 //    	boolean sort = contains( "sort", pageNumber, pageSizeNumber, options );
     	
     	int topNSize = TopNPlayers.getInstance().getTopNSize();
+    	boolean loading = TopNPlayers.getInstance().isLoading();
     	int archivedSize = TopNPlayers.getInstance().getArchivedSize();
     	
     	
@@ -2339,6 +2340,11 @@ public class RanksCommands
     			RankPlayer.printRankScoreLine2Header() : 
     				RankPlayer.printRankScoreLine1Header();
     	sender.sendMessage( header );
+    	
+    	if ( loading ) {
+    		sender.sendMessage( "&3(Loading TopN List - Please Wait)" );
+    	}
+    	
     	
     	for ( int i = posStart; i < posEnd; i++ ) {
     		

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
@@ -1228,9 +1228,9 @@ public class RanksCommands
 		return display;
 	}
 
-	private String padRankName( Rank rank, int maxRankNameSize, int maxRankTagNoColorSize, boolean hasPerm ) {
-		return padRankName( rank.getName(), rank.getTag(), maxRankNameSize, maxRankTagNoColorSize, hasPerm );
-	}
+//	private String padRankName( Rank rank, int maxRankNameSize, int maxRankTagNoColorSize, boolean hasPerm ) {
+//		return padRankName( rank.getName(), rank.getTag(), maxRankNameSize, maxRankTagNoColorSize, hasPerm );
+//	}
     protected String padRankName( String rankName, String rankTag, int maxRankNameSize, int maxRankTagNoColorSize, boolean hasPerm )
 	{
     	StringBuilder sb = new StringBuilder();

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
@@ -1763,6 +1763,11 @@ public class RanksCommands
 			msgs.add( messageSellallMultiplier );
 //			sendToPlayerAndConsole( sender, messageSellallMultiplier );
 
+			List<String> sellallDetails = player.getSellAllMultiplierListings();
+			for (String sellallDetail : sellallDetails) {
+				msgs.add( "    " + sellallDetail );
+			}
+			
 			
 			
 			msgs.add( "" );

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/commands/RanksCommands.java
@@ -768,7 +768,7 @@ public class RanksCommands
 //        }
         
         RankPlayer rPlayer = 
-        		PrisonRanks.getInstance().getPlayerManager().getPlayer( getPlayer(sender) );
+        		PrisonRanks.getInstance().getPlayerManager().getPlayer( sender.getPlatformPlayer() );
         
         ChatDisplay display = null;
         

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/data/TopNPlayers.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/data/TopNPlayers.java
@@ -64,6 +64,9 @@ public class TopNPlayers
 	private long statsSaveDataNanoSec = 0L;
 	private long statsLoadDataNanoSec = 0L;
 	
+	private boolean loading = true;
+	
+	
 	private TopNPlayers() {
 		super();
 		
@@ -797,6 +800,13 @@ public class TopNPlayers
 	}
 	public void setStatsLoadDataNanoSec(long statsLoadDataNanoSec) {
 		this.statsLoadDataNanoSec = statsLoadDataNanoSec;
+	}
+
+	public boolean isLoading() {
+		return loading;
+	}
+	public void setLoading(boolean loading) {
+		this.loading = loading;
 	}
 	
 }

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/managers/PlayerManager.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/managers/PlayerManager.java
@@ -1961,6 +1961,11 @@ public class PlayerManager
 						break;
 				}
 				
+				
+//				results = applySecondaryPlaceholders( rankPlayer, results );
+				
+				
+				
 				if ( attributeText != null && results != null ) {
 					
 					results = attributeText.format( results );
@@ -1974,6 +1979,93 @@ public class PlayerManager
     }
 
 
+    /**
+     * <p>This function will provide support for secondary placeholders for all player related placeholders.
+     * These secondary placeholders are in addition to the preexisting positional placeholders
+     * that are hard coded for the specific parameters. 
+     * </p>
+     * 
+     * <p>These secondary placeholders can be inserted anywhere in the message.
+     * </p>
+     * 
+     * <ul>
+     * 	<li>{player}</li>
+     * 	<li>{rank_default}</li>
+     * 	<li>{rank_tag_default}</li>
+     * 	<li>{rank_next_default}</li>
+     * 	<li>{rank_next_tag_default}</li>
+     * 	<li>{rank_prestiges}</li>
+     * 	<li>{rank_tag_prestiges}</li>
+     * 	<li>{rank_next_prestiges}</li>
+     * 	<li>{rank_next_tag_prestiges}</li>
+     * 
+     *  <li>{player} {rank_default} {rank_tag_default} {rank_next_default} {rank_next_tag_default}</li>
+     * 	<li>{rank_prestiges} {rank_tag_prestiges} {rank_next_prestiges} {rank_next_tag_prestiges}</li>
+     * </ul>
+     * 
+     * @param rankPlayer
+     * @param results
+     * @return
+     */
+	private String applySecondaryPlaceholders(RankPlayer rankPlayer, String results) {
+
+		results = applySecondaryPlaceholdersCheck( "{player}", rankPlayer.getName(), results );
+		
+		if ( rankPlayer.getPlayerRankDefault() != null ) {
+			PlayerRank rankP = rankPlayer.getPlayerRankDefault();
+			Rank rank = rankP == null ? null : rankP.getRank();
+			Rank rankNext = rank == null ? null : rank.getRankNext();
+			
+			results = applySecondaryPlaceholdersCheck( "{rank_default}", 
+					rank == null ? "" : rank.getName(), results );
+			results = applySecondaryPlaceholdersCheck( "{rank_tag_default}", 
+					rank == null ? "" : rank.getTag(), results );
+			
+			results = applySecondaryPlaceholdersCheck( "{rank_next_default}", 
+					rankNext == null ? "" : rankNext.getName(), results );
+			results = applySecondaryPlaceholdersCheck( "{rank_next_tag_default}", 
+					rankNext == null ? "" : rankNext.getTag(), results );
+		}
+		
+		if ( rankPlayer.getPlayerRankPrestiges() != null ) {
+			
+			PlayerRank rankP = rankPlayer.getPlayerRankPrestiges();
+			Rank rank = rankP == null ? null : rankP.getRank();
+			Rank rankNext = rank == null ? null : rank.getRankNext();
+			
+			results = applySecondaryPlaceholdersCheck( "{rank_prestiges}", 
+					rank == null ? "" : rank.getName(), results );
+			results = applySecondaryPlaceholdersCheck( "{rank_tag_prestiges}", 
+					rank == null ? "" : rank.getTag(), results );
+			
+			results = applySecondaryPlaceholdersCheck( "{rank_next_prestiges}", 
+					rankNext == null ? "" : rankNext.getName(), results );
+			results = applySecondaryPlaceholdersCheck( "{rank_next_tag_prestiges}", 
+					rankNext == null ? "" : rankNext.getTag(), results );
+		}
+		
+		return results;
+	}
+
+	/**
+	 * <p>Ths function will perform individual replacements of the given placeholders, but
+	 * if the placeholder does not exist, then it will not change anything with the results
+	 * and it will be just passed through.
+	 * </p>
+	 * 
+	 * @param placeholder
+	 * @param value
+	 * @param results
+	 * @return
+	 */
+	private String applySecondaryPlaceholdersCheck( String placeholder, String value, String results) {
+
+		if ( results.contains( placeholder ) && value != null ) {
+			results = results.replace( placeholder, value );
+		}
+		
+		return results;
+	}
 
 	@Override
     public List<PlaceHolderKey> getTranslatedPlaceHolderKeys() {

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/managers/PlayerManager.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/managers/PlayerManager.java
@@ -729,7 +729,7 @@ public class PlayerManager
     			        	
     			        	if ( attributeNFormat != null ) {
     			        		
-    			        		sb.append( attributeNFormat.format( cost ) );
+    			        		sb.append( attributeNFormat.format( percent ) );
     			        	}
     			        	else {
     			        		

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/managers/RankManager.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/managers/RankManager.java
@@ -962,7 +962,7 @@ public class RankManager
 				{
 					RankPlayer topRankPlayer = getTopNRankPlayer( sequence );
 					
-					if ( topRankPlayer != null && topRankPlayer.getPlayerRankPrestiges() != null ) {
+					if ( topRankPlayer != null && topRankPlayer.getPlayerRankDefault() != null ) {
 						
 						results = topRankPlayer.getPlayerRankDefault().getRank().getTag();
 					}

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/tasks/TopNPlayerUpdateAsyncTask.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/tasks/TopNPlayerUpdateAsyncTask.java
@@ -40,13 +40,20 @@ public class TopNPlayerUpdateAsyncTask
 //		}
 		
 		if ( forceReload ) {
+			topNPlayers.setLoading( true );
+			
 			topNPlayers.forceReloadAllPlayers();
 		
+			topNPlayers.setLoading( false );
 			forceReload = false;
 		}
 		else {
 			
+			topNPlayers.setLoading( true );
+			
 			topNPlayers.refreshAndSort();
+			
+			topNPlayers.setLoading( false );
 		}
 	}
 

--- a/prison-spigot/build.gradle
+++ b/prison-spigot/build.gradle
@@ -149,7 +149,8 @@ dependencies {
     
     
     // https://mvnrepository.com/artifact/com.github.cryptomorin/XSeries
-	implementation 'com.github.cryptomorin:XSeries:9.8.0'
+	implementation 'com.github.cryptomorin:XSeries:9.9.0'
+//	implementation 'com.github.cryptomorin:XSeries:9.8.0'
 	//implementation 'com.github.cryptomorin:XSeries:9.4.0'
 	//implementation 'com.github.cryptomorin:XSeries:9.2.0'
     

--- a/prison-spigot/build.gradle
+++ b/prison-spigot/build.gradle
@@ -136,7 +136,8 @@ dependencies {
 
 
 
-    compileOnly 'me.clip:placeholderapi:2.11.2'
+    compileOnly 'me.clip:placeholderapi:2.11.5'
+    //compileOnly 'me.clip:placeholderapi:2.11.2'
     //compileOnly 'me.clip:placeholderapi:2.10.9'
     
     // Repo may be hosted: https://hub.spigotmc.org/nexus/content/groups/public/

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -48,9 +48,12 @@ import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerChatEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredListener;
 
@@ -2759,17 +2762,19 @@ public class SpigotPlatform
 		blockEvents.dumpEventListeners( sb );
 		
 		
+		// NOTE: the use of '..==..' prevents these packages from being shortened. See end of this function.
+		
 		sb.append( "\n" );
 		sb.append( "&2NOTE: Prison Block Event Listeners:\n" );
 		
 		sb.append( "&2. . Prison Internal BlockBreakEvents: " +
-									"tech.mcprison.prison.spigot.SpigotListener\n" );
+									"tmps.SpigotListener\n" );
 		sb.append( "&2. . Auto Features: " +
-									"tmpsae.AutoManagerBlockBreakEvents$AutoManagerBlockBreakEventListener\n" );
+									"tmps.ae.AutoManagerBlockBreakEvents$AutoManagerBlockBreakEventListener\n" );
 		sb.append( "&2. . Prison's multi-block explosions (bombs): " +
 				"tmpsae.AutoManagerPrisonsExplosiveBlockBreakEvents$AutoManagerExplosiveBlockBreakEventListener\n" );
 		sb.append( "&2. . Prison Abbrv: '&3tmps.&2' = '&3tech..==..mcprison.prison.spigot.&2' & " +
-				"'&3tmpsae.&2' = '&3tmps..==..autofeatures.events.&2'\n" );
+				"'&3tmps.ae.&2' = '&3tmps..==..autofeatures.events.&2'\n" );
 
 		
 //		sb.append( "&2. . Auto Feature Core: Non-AutoManager: " +
@@ -2824,7 +2829,7 @@ public class SpigotPlatform
 		// 'tmpsae.' = 'tmps.autofeatures.events.'
 		String results = sb.toString()
 				.replace( "tech.mcprison.prison.spigot.", "tmps." )
-				.replace( "tmps.autofeatures.events.",  "tmpsae." )
+				.replace( "tmps.autofeatures.events.",  "tmps.ae." )
 				.replace( "..==..", "." );
 		
 		return results;
@@ -2863,6 +2868,52 @@ public class SpigotPlatform
 								new SpigotHandlerList( PlayerInteractEvent.getHandlerList()) );
 		if ( eventDisplay != null ) {
 			sb.append( eventDisplay.toStringBuilder() );
+		}
+		
+		return sb.toString();
+	}
+	
+	@Override
+	public String dumpEventListenersBlockPlaceEvents() {
+		StringBuilder sb = new StringBuilder();
+		
+		ChatDisplay eventDisplay = dumpEventListenersChatDisplay(
+				"BlockPlaceEvent", 
+				new SpigotHandlerList( BlockPlaceEvent.getHandlerList()) );
+		if ( eventDisplay != null ) {
+			sb.append( eventDisplay.toStringBuilder() );
+		}
+		
+		return sb.toString();
+	}
+	
+	@Override
+	public String dumpEventListenersPlayerDropItemEvents() {
+		StringBuilder sb = new StringBuilder();
+		
+		ChatDisplay eventDisplay = dumpEventListenersChatDisplay(
+				"PlayerDropItemEvent", 
+				new SpigotHandlerList( PlayerDropItemEvent.getHandlerList()) );
+		if ( eventDisplay != null ) {
+			sb.append( eventDisplay.toStringBuilder() );
+		}
+		
+		return sb.toString();
+	}
+	
+	@Override
+	public String dumpEventListenersPlayerPickupItemEvents() {
+		StringBuilder sb = new StringBuilder();
+		
+		try {
+			ChatDisplay eventDisplay = dumpEventListenersChatDisplay(
+					"PlayerPickupItemEvent", 
+					new SpigotHandlerList( PlayerPickupItemEvent.getHandlerList()) );
+			if ( eventDisplay != null ) {
+				sb.append( eventDisplay.toStringBuilder() );
+			}
+		} catch (Exception e) {
+			sb.append( "The PlayerPickupItemEvent is not valid on this version of spigot." );
 		}
 		
 		return sb.toString();

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -187,14 +187,17 @@ public class SpigotPlatform
     	
         this.plugin = plugin;
         this.scoreboardManager = new SpigotScoreboardManager();
-        this.storage = initStorage();
+        
+        
+        this.storage = null;
+//        this.storage = initStorage();
         
         this.placeholders = new SpigotPlaceholders();
 
         ActionBarUtil.init(plugin);
     }
 
-    private Storage initStorage() {
+    public Storage initStorage() {
         String confStorage = plugin.getConfig().getString("storage", "file");
         Storage storage = new FileStorage(plugin.getDataDirectory());
         
@@ -205,6 +208,7 @@ public class SpigotPlatform
                 "Note: In this version of Prison 3, 'file' is the only supported type of storage. We're working to bring other storage types soon.");
         }
         
+        this.storage = storage;
         return storage;
     }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -204,12 +204,12 @@ public class SpigotPlatform
         String confStorage = plugin.getConfig().getString("storage", "file");
         Storage storage = new FileStorage(plugin.getDataDirectory());
         
-        if (!confStorage.equalsIgnoreCase("file")) {
-            Output.get().logError("Unknown file storage type in configuration \"" + confStorage
-                + "\". Using file storage.");
-            Output.get().logWarn(
-                "Note: In this version of Prison 3, 'file' is the only supported type of storage. We're working to bring other storage types soon.");
-        }
+//        if (!confStorage.equalsIgnoreCase("file")) {
+//            Output.get().logError("Unknown file storage type in configuration \"" + confStorage
+//                + "\". Using file storage.");
+//            Output.get().logWarn(
+//                "Note: In this version of Prison 3, 'file' is the only supported type of storage. We're working to bring other storage types soon.");
+//        }
         
         this.storage = storage;
         return storage;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -2998,7 +2998,15 @@ public class SpigotPlatform
 	
 	@Override
 	public void saveResource( String fileName, boolean replace ) {
-		SpigotPrison.getInstance().saveResource( fileName, replace );
+		
+		try {
+			SpigotPrison.getInstance().saveResource( fileName, replace );
+		} catch (Exception e) {
+			Output.get().logInfo( 
+					"SpigotPlatformm.saveResource(): Error trying to save a resource '%s'  replace=%s : %s",
+					fileName, Boolean.toString(replace), e.getMessage()
+					);
+		}
 	}
 	
 	@Override

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPlatform.java
@@ -204,7 +204,9 @@ public class SpigotPlatform
     }
 
     public Storage initStorage() {
-        String confStorage = plugin.getConfig().getString("storage", "file");
+    	
+        @SuppressWarnings("unused")
+		String confStorage = plugin.getConfig().getString("storage", "file");
         Storage storage = new FileStorage(plugin.getDataDirectory());
         
 //        if (!confStorage.equalsIgnoreCase("file")) {
@@ -1469,9 +1471,9 @@ public class SpigotPlatform
 				PrisonRanks.getInstance() != null && PrisonRanks.getInstance().isEnabled() 
 				) {
 			
-    		PlayerManager pm = PrisonRanks.getInstance().getPlayerManager();
-    		Player player = pm.getPlayer( sender );
-    		RankPlayer rankPlayer = pm.getPlayer( player );
+//    		PlayerManager pm = PrisonRanks.getInstance().getPlayerManager();
+//    		Player player = sender.getPlatformPlayer();
+    		RankPlayer rankPlayer = sender.getRankPlayer();
 
     		RankPlayerFactory rankPlayerFactory = new RankPlayerFactory();
     		

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
@@ -218,13 +218,20 @@ public class SpigotPrison
         // prior to starting up:
         initCommandMap();
         this.scheduler = new SpigotScheduler(this);
+
+        
+        Prison.get();
         
         SpigotPlatform platform = new SpigotPlatform(this);
+
+        Prison.get().init( platform, Bukkit.getVersion() );
         
+        // Initialize storage after setting the platformm in the Prison.get():
+        platform.initStorage();
+
 
         // Show Prison's splash screen and setup the core components:
-        Prison.get()
-        		.init( platform, Bukkit.getVersion(), getDataFolder() );
+        Prison.get().init( getDataFolder() );
 
         
         

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/SpigotPrison.java
@@ -20,6 +20,7 @@ package tech.mcprison.prison.spigot;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -1335,6 +1336,14 @@ public class SpigotPrison
 
     public YamlConfiguration loadConfig(String file) {
         return YamlConfiguration.loadConfiguration(getBundledFile(file));
+    }
+    
+    public YamlConfiguration loadExternalConfig(File file) {
+    	return YamlConfiguration.loadConfiguration( file );
+    }
+    
+    public YamlConfiguration loadExternalConfig( Reader reader ) {
+    	return YamlConfiguration.loadConfiguration( reader );
     }
     
     public void saveConfig(String fileName, YamlConfiguration config ) {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/api/PrisonMinesBlockBreakEvent.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/api/PrisonMinesBlockBreakEvent.java
@@ -140,6 +140,9 @@ public class PrisonMinesBlockBreakEvent
 	private List<Block> unprocessedRawBlocks;
 	
 	
+	private boolean applyToPlayersBlockCount;
+	
+	
 	private StringBuilder debugInfo;
 	private boolean forceDebugLogging;
 
@@ -194,6 +197,8 @@ public class PrisonMinesBlockBreakEvent
 		
 		this.forceDebugLogging = false;
 		
+		this.applyToPlayersBlockCount = true;
+		
 	}
 	
 	public PrisonMinesBlockBreakEvent( Block theBlock, Player player, 
@@ -223,6 +228,8 @@ public class PrisonMinesBlockBreakEvent
 		this.bukkitDrops = new ArrayList<>();
 		
 		this.debugInfo = debugInfo;
+		
+		this.applyToPlayersBlockCount = true;
 		
 	}
 
@@ -505,6 +512,13 @@ public class PrisonMinesBlockBreakEvent
 	}
 	public void setForceIfAirBlock( boolean forceIfAirBlock ) {
 		this.forceIfAirBlock = forceIfAirBlock;
+	}
+
+	public boolean isApplyToPlayersBlockCount() {
+		return applyToPlayersBlockCount;
+	}
+	public void setApplyToPlayersBlockCount(boolean applyToPlayersBlockCount) {
+		this.applyToPlayersBlockCount = applyToPlayersBlockCount;
 	}
 
 	@Override

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/api/PrisonSpigotAPI.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/api/PrisonSpigotAPI.java
@@ -51,14 +51,80 @@ import tech.mcprison.prison.util.Location;
  * <p>If you need something special, then please ask on our discord server and we 
  * can probably provide it for you.
  * </p>
+ * @param <PrisonItemStack>
  *
  */
-public class PrisonSpigotAPI {
+public class PrisonSpigotAPI<PrisonItemStack> {
 	
 	private PrisonMines prisonMineManager;
 	private boolean mineModuleDisabled = false;
 	private SellAllUtil sellAll;
 	
+	
+	private void junk() {
+		
+//		SpigotPrison.getInstance().isSellAllEnabled();
+//		
+//		SpigotPlayer sPlayer = new SpigotPlayer( Player player );
+//		
+//		sPlayer.getSellAllMulitiplier()
+//		sPlayer.getSellAllMultiplierListings()
+//		sPlayer.checkAutoSellPermsAutoFeatures()
+//		sPlayer.checkAutoSellTogglePerms( sbDebug )
+//		sPlayer.isAutoSellEnabled( sbDebug )
+//		
+		
+	//	PrisonSpigotAPI.sellPlayerItems(Player player );
+	}
+
+//	private void handleAffectedBlocks(Player p, IWrappedRegion region, List<Block> blocksAffected) {
+//        double totalDeposit = 0.0;
+//        int fortuneLevel = EnchantUtils.getItemFortuneLevel(p.getItemInHand());
+//        boolean autoSellPlayerEnabled = this.plugin.isAutoSellModuleEnabled() && plugin.getCore().getAutoSell().getManager().hasAutoSellEnabled(p);
+//
+//        TreeMap<String,Double> itemValues = new TreeMap<>();
+//        PrisonSpigotAPI pApi = new PrisonSpigotAPI();
+//        
+//        getItemStackValueTransactions(p, null);
+//        
+//        for (Block block : blocksAffected) {
+//
+//        	int amplifier = fortuneLevel;
+//            if (FortuneEnchant.isBlockBlacklisted(block)) {
+//                amplifier = 1;
+//            }
+//            
+//            String blockNamme = block.getType().name();
+//            double value = 0dg;
+//            
+//            if ( itemValues.containsKey(blockNamme) ) {
+//            	value = itemValues.get(blockNamme);
+//            }
+//            else {
+//            	ItemStack iStk = new ItemStack( block.getType() );
+//            	if ( iStk != null ) {
+//            		
+//            		value = getItemStackValue(p, iStk);
+//            		if ( value > 0 ) {{
+//            			itemValues.put(blockNamme, value);
+//            		}
+//            	}
+//            }
+//
+//            if (autoSellPlayerEnabled && value > 0) {
+//                totalDeposit += value * amplifier;
+//            } else {
+//                ItemStack itemToGive = CompMaterial.fromBlock(block).toItem(amplifier);
+//                p.getInventory().addItem(itemToGive);
+//            }
+//
+//            if (this.removeBlocks ) {
+//                this.plugin.getCore().getNmsProvider().setBlockInNativeDataPalette(block.getWorld(), block.getX(), block.getY(), block.getZ(), 0, (byte) 0, true);
+//            }
+//
+//        }
+//        this.giveEconomyRewardsToPlayer(p, totalDeposit);
+//    }
 
 	/**
 	 * <p>This returns all mines that are within prison.
@@ -479,6 +545,94 @@ public class PrisonSpigotAPI {
 		}
 
 		return sellAll;
+	}
+	
+	
+	/**
+	 * <p>This will convert a List<org.bukkit.block.Block> to Prison's
+	 * List<SpigotItemStack> so it can be used with the various SellAll 
+	 * functions.
+	 * </p>
+	 * 
+	 * @param blocks
+	 * @return
+	 */
+	public List<SpigotItemStack> getPrisonItemmStacks( List<Block> blocks ) {
+		List<SpigotItemStack> results = new ArrayList<>();
+		TreeMap<String, SpigotItemStack> map = new TreeMap<>();
+		
+		if ( blocks != null ) {
+			for ( Block b : blocks ) {
+				if ( b != null ) {
+					SpigotBlock sBlock = SpigotBlock.getSpigotBlock( b );
+					
+					if ( sBlock != null ) {
+						
+						String bName = sBlock.getBlockName();
+						
+						if ( !map.containsKey( bName ) ) {
+							String[] lore = null;
+							SpigotItemStack sis = new SpigotItemStack( 1, sBlock, lore );
+							
+							map.put(bName, sis );
+						}
+						else {
+							map.get(bName).addToAmount( 1 );
+						}
+					}
+					
+				}
+			}
+		
+		}
+		
+		if ( map.size() > 0 ) {
+			for ( SpigotItemStack sItemStack : map.values() ) {
+				results.add( sItemStack );
+			}
+		}
+		
+		return results;
+	}
+	
+	public List<ItemStack> getItemStacks( List<Block> blocks ) {
+		List<ItemStack> results = new ArrayList<>();
+		TreeMap<String, ItemStack> map = new TreeMap<>();
+		
+		if ( blocks != null ) {
+			for ( Block b : blocks ) {
+				if ( b != null ) {
+					
+					String bName = b.getType().name();
+							
+					if ( bName != null ) {
+						
+						if ( !map.containsKey( bName ) ) {
+							
+							ItemStack iStk = new ItemStack( b.getType() );
+							map.put(bName, iStk );
+						}
+						else {
+							ItemStack iStk = map.get(bName);
+
+							iStk.setAmount( iStk.getAmount() );
+							
+							map.put(bName, iStk);
+						}
+					}
+					
+				}
+			}
+			
+		}
+		
+		if ( map.size() > 0 ) {
+			for ( ItemStack sItemStack : map.values() ) {
+				results.add( sItemStack );
+			}
+		}
+		
+		return results;
 	}
 
 	/**

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
@@ -917,6 +917,9 @@ public abstract class AutoManagerFeatures
 //							  SellAllUtil.get().isSellallPlayerUserToggleEnabled( 
 //												pmEvent.getSpigotPlayer().getWrapper() ));
 			
+			
+			// isAutoSellEnabled should include perms check too:
+			
 			boolean isPlayerAutosellEnabled = pmEvent.getSpigotPlayer().isAutoSellEnabled( pmEvent.getDebugInfo() );
 			
 			
@@ -939,11 +942,12 @@ public abstract class AutoManagerFeatures
 //							!"false".equalsIgnoreCase( getMessage( AutoFeatures.permissionAutoSellPerBlockBreakEnabled ) ) &&
 //							player.hasPermission( getMessage( AutoFeatures.permissionAutoSellPerBlockBreakEnabled ) );
 			
-			boolean autoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( isPlayerAutosellEnabled, pmEvent.getDebugInfo()  );
+//			boolean autoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( isPlayerAutosellEnabled, pmEvent.getDebugInfo()  );
 			
 			
 			// Try to autosell if enabled in any of the following ways:
-			boolean autoSell = ( forceAutoSell || autoSellBySettings || autoSellByPerm );
+			boolean autoSell = ( forceAutoSell || autoSellBySettings );
+//			boolean autoSell = ( forceAutoSell || autoSellBySettings || autoSellByPerm );
 			
 			for ( SpigotItemStack itemStack : drops ) {
 				
@@ -999,7 +1003,8 @@ public abstract class AutoManagerFeatures
 					
 					
 					// AutoSell failure... some items may be unsellable due to not being setup in the sellall shop:
-					if ( forceAutoSell || autoSellBySettings || autoSellByPerm ) {
+					if ( forceAutoSell || autoSellBySettings ) {
+//						if ( forceAutoSell || autoSellBySettings || autoSellByPerm ) {
 						
 						// Force debug printing for this entry even if debug mode is turned off:
 						pmEvent.setForceDebugLogging( true );
@@ -1468,9 +1473,10 @@ public abstract class AutoManagerFeatures
 				
 				boolean isPlayerAutosellEnabled = sPlayer.isAutoSellEnabled( debugInfo );
 				
-				boolean isPlayerAutoSellByPerm = sPlayer.isAutoSellByPermEnabled( isPlayerAutosellEnabled, debugInfo );
+//				boolean isPlayerAutoSellByPerm = sPlayer.isAutoSellByPermEnabled( isPlayerAutosellEnabled, debugInfo );
 			
-				if ( isPlayerAutosellEnabled || isPlayerAutoSellByPerm ) {
+				if ( isPlayerAutosellEnabled ) {
+//					if ( isPlayerAutosellEnabled || isPlayerAutoSellByPerm ) {
 				
 					SellAllUtil sellAllUtil = SellAllUtil.get();
 				

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/AutoManagerFeatures.java
@@ -939,7 +939,7 @@ public abstract class AutoManagerFeatures
 //							!"false".equalsIgnoreCase( getMessage( AutoFeatures.permissionAutoSellPerBlockBreakEnabled ) ) &&
 //							player.hasPermission( getMessage( AutoFeatures.permissionAutoSellPerBlockBreakEnabled ) );
 			
-			boolean autoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( isPlayerAutosellEnabled );
+			boolean autoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( isPlayerAutosellEnabled, pmEvent.getDebugInfo()  );
 			
 			
 			// Try to autosell if enabled in any of the following ways:
@@ -1468,7 +1468,7 @@ public abstract class AutoManagerFeatures
 				
 				boolean isPlayerAutosellEnabled = sPlayer.isAutoSellEnabled( debugInfo );
 				
-				boolean isPlayerAutoSellByPerm = sPlayer.isAutoSellByPermEnabled( isPlayerAutosellEnabled );
+				boolean isPlayerAutoSellByPerm = sPlayer.isAutoSellByPermEnabled( isPlayerAutosellEnabled, debugInfo );
 			
 				if ( isPlayerAutosellEnabled || isPlayerAutoSellByPerm ) {
 				

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/events/AutoManagerBlockBreakEvents.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/events/AutoManagerBlockBreakEvents.java
@@ -516,14 +516,16 @@ public class AutoManagerBlockBreakEvents
 //						isBoolean(AutoFeatures.isAutoSellPerBlockBreakEnabled);
     		
     		
-    		boolean isPlayerAutoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( 
-    							isPlayerAutosellEnabled,  pmEvent.getDebugInfo()  );
+//    		boolean isPlayerAutoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( 
+//    							isPlayerAutosellEnabled,  pmEvent.getDebugInfo()  );
     		
     		
     		
     		
     		if ( isBoolean( AutoFeatures.isForceSellAllOnInventoryWhenBukkitBlockBreakEventFires ) && 
-    				( isPlayerAutosellEnabled || isPlayerAutoSellByPerm )) {
+    								isPlayerAutosellEnabled ) {
+    			
+//    			( isPlayerAutosellEnabled || isPlayerAutoSellByPerm )) {
     			
     			pmEvent.getDebugInfo().append( Output.get().getColorCodeWarning());
     			pmEvent.performSellAllOnPlayerInventoryLogged( "FORCED BlockBreakEvent sellall");
@@ -531,7 +533,9 @@ public class AutoManagerBlockBreakEvents
     		}
     		
     		if ( isBoolean( AutoFeatures.isEnabledDelayedSellAllOnInventoryWhenBukkitBlockBreakEventFires ) && 
-    				( isPlayerAutosellEnabled || isPlayerAutoSellByPerm ) ) {
+    								isPlayerAutosellEnabled ) {
+    			
+//    			( isPlayerAutosellEnabled || isPlayerAutoSellByPerm ) ) {
     			
     			if ( !getDelayedSellallPlayers().contains( pmEvent.getSpigotPlayer() ) ) {
     				

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/events/AutoManagerBlockBreakEvents.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/events/AutoManagerBlockBreakEvents.java
@@ -516,7 +516,8 @@ public class AutoManagerBlockBreakEvents
 //						isBoolean(AutoFeatures.isAutoSellPerBlockBreakEnabled);
     		
     		
-    		boolean isPlayerAutoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( isPlayerAutosellEnabled );
+    		boolean isPlayerAutoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( 
+    							isPlayerAutosellEnabled,  pmEvent.getDebugInfo()  );
     		
     		
     		

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/events/AutoManagerPrisonsExplosiveBlockBreakEvents.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/autofeatures/events/AutoManagerPrisonsExplosiveBlockBreakEvents.java
@@ -334,6 +334,10 @@ public class AutoManagerPrisonsExplosiveBlockBreakEvents
     		// removed, then it's removed within this funciton.
     		removeEventTriggerBlocksFromExplosions( pmEvent );
     		
+    		
+    		
+    		pmEvent.setApplyToPlayersBlockCount( 
+    				e.getMineBomb().isApplyToPlayersBlockCount() );
   
 			
 			if ( !validateEvent( pmEvent ) ) {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/block/OnBlockBreakEventCore.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/block/OnBlockBreakEventCore.java
@@ -935,15 +935,15 @@ public abstract class OnBlockBreakEventCore
 //											pmEvent.getPlayer() ));
 					
 					
-					boolean isPlayerAutoSellByPerm = pmEvent.getSpigotPlayer()
-									.isAutoSellByPermEnabled( isPlayerAutosellEnabled, pmEvent.getDebugInfo()  );
+//					boolean isPlayerAutoSellByPerm = pmEvent.getSpigotPlayer()
+//									.isAutoSellByPermEnabled( isPlayerAutosellEnabled, pmEvent.getDebugInfo()  );
 		    		
 					 	
 					
 					
 					// AutoSell on full inventory when using BLOCKEVENTS:
 					if ( isBoolean( AutoFeatures.isAutoSellIfInventoryIsFullForBLOCKEVENTSPriority ) &&
-							( isPlayerAutosellEnabled || isPlayerAutoSellByPerm ) &&
+							isPlayerAutosellEnabled &&
 							pmEvent.getSpigotPlayer().isInventoryFull() ) {
 						
 						pmEvent.performSellAllOnPlayerInventoryLogged("BLOCKEVENTS priority sellall");

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/block/OnBlockBreakEventCore.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/block/OnBlockBreakEventCore.java
@@ -935,7 +935,8 @@ public abstract class OnBlockBreakEventCore
 //											pmEvent.getPlayer() ));
 					
 					
-					boolean isPlayerAutoSellByPerm = pmEvent.getSpigotPlayer().isAutoSellByPermEnabled( isPlayerAutosellEnabled );
+					boolean isPlayerAutoSellByPerm = pmEvent.getSpigotPlayer()
+									.isAutoSellByPermEnabled( isPlayerAutosellEnabled, pmEvent.getDebugInfo()  );
 		    		
 					 	
 					

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/block/OnBlockBreakEventCore.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/block/OnBlockBreakEventCore.java
@@ -1167,9 +1167,13 @@ public abstract class OnBlockBreakEventCore
 			if ( mine.incrementBlockMiningCount( targetBlock ) ) {
 				results = true;
 				
-				// Now in AutoManagerFeatures.autoPickup and calculateNormalDrop:
-				PlayerCache.getInstance().addPlayerBlocks( pmEvent.getSpigotPlayer(), 
-						mine.getName(), targetBlock.getPrisonBlock(), 1 );
+				
+				if ( pmEvent.isApplyToPlayersBlockCount() ) {
+					
+					// Now in AutoManagerFeatures.autoPickup and calculateNormalDrop:
+					PlayerCache.getInstance().addPlayerBlocks( pmEvent.getSpigotPlayer(), 
+							mine.getName(), targetBlock.getPrisonBlock(), 1 );
+				}
 				
 			}
 		}

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/block/SpigotItemStack.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/block/SpigotItemStack.java
@@ -265,6 +265,15 @@ public class SpigotItemStack
 //    	}
     }
     
+    
+    
+    public String getNBTItemStackInfo() {
+    	
+    	String results = PrisonNBTUtil.nbtDebugString(getBukkitStack()) ;
+    	
+    	return results;
+    }
+    
 //    public int getNBTInt( String key ) {
 //    	int results = -1;
 //    	
@@ -348,6 +357,18 @@ public class SpigotItemStack
 			bukkitStack.setAmount( amount );
 		}
 	}
+	
+	/**
+	 * <p>This function will add the given amount to the item stack's total amount.
+	 * </p>
+	 * 
+	 * @param i amount to add to this itemStack
+	 */
+	public void addToAmount( int i ) {
+		int amt = getAmount() + i;
+		setAmount( amt );
+	}
+	
 	
 	private ItemMeta getMeta() {
 		ItemMeta meta;
@@ -468,6 +489,19 @@ public class SpigotItemStack
 				
 		return sItemStack;
 	}
+	
+	public Map<Enchantment, Integer> getEnchantments() {
+		Map<Enchantment, Integer> results = null;
+		
+		ItemMeta meta = getMeta();
+		if ( meta != null && 
+				meta.getEnchants() != null &&
+				meta.getEnchants().size() > 0 ) {
+			
+			results = meta.getEnchants();
+		}
+        return results;
+    }
 
 	/**
 	 * <p>This function will return information on the item in the item stack, which is for 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotGUIBackPackCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotGUIBackPackCommands.java
@@ -40,7 +40,10 @@ public class PrisonSpigotGUIBackPackCommands
         }
 
         if (getBoolean(BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission_Enabled")) && !p.hasPermission(BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission"))){
-            Output.get().sendWarn(sender, SpigotPrison.format(messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission") + "]"));
+            Output.get().sendWarn(sender, SpigotPrison.format(
+            		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//            			+ " [" + BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission") + "]"
+            			));
             return;
         }
 
@@ -71,7 +74,10 @@ public class PrisonSpigotGUIBackPackCommands
         // New method.
         if (getBoolean(BackpacksUtil.get().getBackpacksConfig().getString("Options.Multiple-BackPacks-For-Player-Enabled"))){
             if (getBoolean(BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission_Enabled")) && !p.hasPermission(BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission"))){
-                Output.get().sendWarn(sender, SpigotPrison.format(messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission") + "]"));
+                Output.get().sendWarn(sender, SpigotPrison.format(
+                		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + BackpacksUtil.get().getBackpacksConfig().getString("Options.BackPack_Use_Permission") + "]"
+                		));
                 return;
             }
             BackpacksListPlayerGUI gui = new BackpacksListPlayerGUI(p);

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotGUICommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotGUICommands.java
@@ -86,8 +86,10 @@ public class PrisonSpigotGUICommands extends PrisonSpigotBaseCommands {
             String perm = getConfig( "Options.Prestiges.Permission_GUI");
 
             if ( !sender.hasPermission( perm ) ){
-                Output.get().sendInfo(sender, SpigotPrison.format(messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" +
-                        perm + "]"));
+                Output.get().sendInfo(sender, SpigotPrison.format(
+                		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + perm + "]"
+                		));
                 return;
             }
         }
@@ -142,8 +144,10 @@ public class PrisonSpigotGUICommands extends PrisonSpigotBaseCommands {
             String perm = getConfig( "Options.Mines.Permission_GUI");
 
             if ( !sender.hasPermission( perm ) ){
-                Output.get().sendInfo(sender, SpigotPrison.format( getMessages().getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" +
-                        perm + "]"));
+                Output.get().sendInfo(sender, SpigotPrison.format( 
+                		getMessages().getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + perm + "]"
+                        ));
                 return;
             }
         }
@@ -225,8 +229,10 @@ public class PrisonSpigotGUICommands extends PrisonSpigotBaseCommands {
             String perm = getConfig( "Options.Ranks.Permission_GUI");
             if (!sender.hasPermission(perm)) {
 
-                Output.get().sendInfo(sender, SpigotPrison.format( getMessages().getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" +
-                        perm + "]"));
+                Output.get().sendInfo(sender, SpigotPrison.format( 
+                		getMessages().getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + perm + "]"
+                        ));
                 return;
             }
         }
@@ -345,8 +351,10 @@ public class PrisonSpigotGUICommands extends PrisonSpigotBaseCommands {
     		String perm = getConfig( "Options.Ranks.Permission_GUI");
     		if (!sender.hasPermission(perm)) {
     			
-    			Output.get().sendInfo(sender, SpigotPrison.format( getMessages().getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" +
-    					perm + "]"));
+    			Output.get().sendInfo(sender, SpigotPrison.format( 
+    					getMessages().getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//    					+ " [" + perm + "]"
+    					));
     			return;
     		}
     	}

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
@@ -320,7 +320,10 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         if (sellAllUtil.isSellAllSellPermissionEnabled){
             String permission = sellAllUtil.permissionSellAllSell;
             if (permission == null || !p.hasPermission(permission)){
-                Output.get().sendWarn(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + permission + "]");
+                Output.get().sendWarn(new SpigotPlayer(p), 
+                		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission)
+//                		+ " [" + permission + "]"
+                		);
                 return;
             }
         }
@@ -360,7 +363,10 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         if (sellAllUtil.isSellAllSellPermissionEnabled){
             String permission = sellAllUtil.permissionSellAllSell;
             if (permission == null || !p.hasPermission(permission)){
-                Output.get().sendWarn(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + permission + "]");
+                Output.get().sendWarn(new SpigotPlayer(p), 
+                		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + permission + "]"
+                		);
                 return;
             }
         }
@@ -393,7 +399,10 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         if (sellAllUtil.isSellAllSellPermissionEnabled){
             String permission = sellAllUtil.permissionSellAllSell;
             if (permission == null || !p.hasPermission(permission)){
-                Output.get().sendWarn(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + permission + "]");
+                Output.get().sendWarn(new SpigotPlayer(p), 
+                		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + permission + "]"
+                		);
                 return;
             }
         }
@@ -468,7 +477,10 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         if (sellAllUtil.isSellAllSellPermissionEnabled){
             String permission = sellAllUtil.permissionSellAllSell;
             if (permission == null || !p.hasPermission(permission)){
-                Output.get().sendWarn(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + permission + "]");
+                Output.get().sendWarn(new SpigotPlayer(p), 
+                		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + permission + "]"
+                		);
                 return;
             }
         }
@@ -510,7 +522,10 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         if (sellAllUtil.isSellAllSellPermissionEnabled){
             String permission = sellAllUtil.permissionSellAllSell;
             if (permission == null || !p.hasPermission(permission)){
-                Output.get().sendWarn(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + permission + "]");
+                Output.get().sendWarn(new SpigotPlayer(p), 
+                		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + permission + "]"
+                		);
                 return;
             }
         }
@@ -550,7 +565,10 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         if (sellAllUtil.isSellAllSellPermissionEnabled){
             String permission = sellAllUtil.permissionSellAllSell;
             if (permission == null || !p.hasPermission(permission)){
-                Output.get().sendWarn(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + permission + "]");
+                Output.get().sendWarn(new SpigotPlayer(p), 
+                		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                		+ " [" + permission + "]"
+                		);
                 return;
             }
         }
@@ -598,7 +616,10 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
 
         String permission = sellAllUtil.permissionAutoSellPerUserToggleable;
         if (sellAllUtil.isAutoSellPerUserToggleablePermEnabled && (permission != null && !p.hasPermission(permission))){
-            Output.get().sendWarn(sender, messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [" + permission + "]");
+            Output.get().sendWarn(sender, 
+            		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//            		+ " [" + permission + "]"
+            		);
             return;
         }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
@@ -597,9 +597,13 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
         	return;
         }
+        StringBuilder debugInfo = new StringBuilder();
+        debugInfo.append( "[sellall autoSellToggle] " );
+        	
         SellAllUtil sellAllUtil = SellAllUtil.get();
 
         Player p = getSpigotPlayer(sender);
+        SpigotPlayer sPlayer = new SpigotPlayer(p);
 
         // Sender must be a Player, not something else like the Console.
         if (p == null) {
@@ -614,8 +618,11 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
             return;
         }
 
-        String permission = sellAllUtil.permissionAutoSellPerUserToggleable;
-        if (sellAllUtil.isAutoSellPerUserToggleablePermEnabled && (permission != null && !p.hasPermission(permission))){
+        boolean hasAutosellPerms = sPlayer.checkAutoSellTogglePerms( debugInfo );
+        
+//        String permission = sellAllUtil.permissionAutoSellPerUserToggleable;
+        if ( sellAllUtil.isAutoSellPerUserToggleablePermEnabled && !hasAutosellPerms ) {
+//        	if (sellAllUtil.isAutoSellPerUserToggleablePermEnabled && (permission != null && !p.hasPermission(permission))){
             Output.get().sendWarn(sender, 
             		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
 //            		+ " [" + permission + "]"
@@ -623,13 +630,22 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
             return;
         }
 
-        boolean isplayerAutosellEnabled = sellAllUtil.isPlayerAutoSellEnabled(p);
-        if (sellAllUtil.setAutoSellPlayer(p, !isplayerAutosellEnabled)){
-            if ( !isplayerAutosellEnabled ){ // Note this variable was negated then saved, so we need to check the negative:
-                Output.get().sendInfo(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_sellall_auto_disabled));
-            } else {
-            	Output.get().sendInfo(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_sellall_auto_enabled));
+        boolean isplayerAutosellEnabled = sellAllUtil.isSellallPlayerUserToggleEnabled(p);
+        if (sellAllUtil.setAutoSellPlayer(p, !isplayerAutosellEnabled)) {
+            if ( isplayerAutosellEnabled  ){ 
+                String msg = messages.getString(MessagesConfig.StringID.spigot_message_sellall_auto_disabled);
+            	
+            	Output.get().sendInfo( sPlayer, msg );
+            } 
+            else {
+            	String msg = messages.getString(MessagesConfig.StringID.spigot_message_sellall_auto_enabled);
+            	
+            	Output.get().sendInfo( sPlayer, msg );
             }
+        }
+        
+        if ( Output.get().isDebug() ) {
+        	Output.get().logInfo( debugInfo.toString() );
         }
     }
 //

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
@@ -865,6 +865,66 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     }
 
     
+    @Command(identifier = "sellall items allowLore", 
+    		description = "Edits an existing SellAll shop item to either allow the sellable items "
+    				+ "to have lore or not.  If an item is not allowed to have lore, but the itemm "
+    				+ "that is intended to be sold has lore, then the item will not be sellable..", 
+    		permissions = "prison.admin", onlyPlayers = false)
+    private void sellAllAllowLoreCommand(CommandSender sender,
+    		@Arg(name = "Item_ID", description = "The Item_ID or block to add to the sellAll Shop.") String itemID,
+    		@Arg(name = "allowLore", description = "Allow lore to be used. "
+    				+ "Default: 'false'. [true, allow, false] Invalid values are treated as 'false'.", 
+    				def = "false") 
+    			String isLoreAllowed ){
+    	
+    	if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+    		return;
+    	}
+    	SellAllUtil sellAllUtil = SellAllUtil.get();
+    	
+    	if (itemID == null){
+    		Output.get().sendWarn(sender, messages.getString(MessagesConfig.StringID.spigot_message_sellall_item_missing_name));
+    		return;
+    	}
+    	itemID = itemID.toUpperCase();
+    	
+    	
+    	if (sellAllUtil.sellAllConfig.getConfigurationSection("Items." + itemID) == null){
+    		Output.get().sendWarn(sender, itemID + " " + messages.getString(MessagesConfig.StringID.spigot_message_sellall_item_not_found));
+    		return;
+    	}
+    	
+    	boolean allowLore = false;
+    	
+    	if ( isLoreAllowed != null && 
+    			("true".equalsIgnoreCase(isLoreAllowed) || "allow".equalsIgnoreCase(isLoreAllowed)) ) {
+    		allowLore = true;
+    	}
+    		
+    		
+//    	sender.sendMessage("not yet enabled");
+//    	return;
+    	
+    	try {
+    		XMaterial blockAdd;
+    		try {
+    			blockAdd = XMaterial.valueOf(itemID);
+    		} catch (IllegalArgumentException ex){
+    			Output.get().sendError(sender, messages.getString(MessagesConfig.StringID.spigot_message_sellall_item_id_not_found) + " [" + itemID + "]");
+    			return;
+    		}
+    		
+    		if (sellAllUtil.editAllowLore(blockAdd, allowLore )) {
+    			
+    			Output.get().sendInfo(sender, "&3ITEM [" + itemID + ", allowLore= " + allowLore + "] " + messages.getString(MessagesConfig.StringID.spigot_message_sellall_item_edit_success));
+    		}
+    		
+    	} catch (IllegalArgumentException ex){
+    		Output.get().sendError(sender, messages.getString(MessagesConfig.StringID.spigot_message_sellall_item_id_not_found) + " [" + itemID + "]");
+    	}
+    }
+    
+    
     @Command(identifier = "sellall multiplier list", 
     		description = "Lists all of the SellAll Rank multipliers", 
     		permissions = "prison.admin", onlyPlayers = false)

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/commands/PrisonSpigotSellAllCommands.java
@@ -47,7 +47,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     /**
      * Check if SellAll's enabled.
      * */
-    public static boolean isEnabled(){
+    public static boolean isEnabled() {
     	
     	return SpigotPrison.getInstance().isSellAllEnabled();
     }
@@ -58,9 +58,6 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     public static PrisonSpigotSellAllCommands get() {
         if (instance == null && isEnabled()) {
             instance = new PrisonSpigotSellAllCommands();
-        }
-        if (instance == null){
-            return null;
         }
         return instance;
     }
@@ -92,7 +89,9 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     		onlyPlayers = false)
     private void sellAllCommands(CommandSender sender) {
 
-        if (!isEnabled()) return;
+        if ( !isEnabled() ) {
+        	return;
+        }
 
         if (sender.hasPermission("prison.admin")) {
         	sender.dispatchCommand("sellall help");
@@ -115,7 +114,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
            		description = "True to enable or false to disable.", 
            		def = "false") String enable){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ){
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -153,7 +152,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
             @Arg(name = "delay", 
             description = "Set delay value in seconds. Defaults to a value of 15 seconds.", def = "15") String delay){
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -182,7 +181,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
          			+ "[true false perUserToggleable]", 
          		def = "true") String enable){
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ){
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -229,7 +228,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
         description = "'True' to enable or 'false' to disable. [true false]", 
         def = "") String enable){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if (!isEnabled() ){
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -266,7 +265,9 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
                     description = "Notification behavior for the sellall transaction. Defaults to normal. " +
                     "'silent' suppresses all notifications. [silent]") String notification ){
 
-        if (!isEnabled()) return;
+        if ( !isEnabled() ) {
+        	return;
+        }
 
         Player p = getSpigotPlayer(sender);
         
@@ -341,7 +342,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     		onlyPlayers = true)
     public void sellAllSellHandCommand(CommandSender sender){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ){
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -383,7 +384,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     }
 
     public void sellAllSell(Player p){
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ){
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -425,7 +426,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     				"Only console or prison commands can include this parameter") String playerName
              ){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -500,7 +501,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     		onlyPlayers = true)
     public void sellAllValueOfHandCommand(CommandSender sender){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ){
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -547,7 +548,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
             onlyPlayers = true)
     public void sellAllSellWithDelayCommand(CommandSender sender){
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -594,7 +595,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     		altPermissions = "prison.sellall.toggle", onlyPlayers = true)
     private void sellAllAutoEnableUser(CommandSender sender){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
         	return;
         }
         StringBuilder debugInfo = new StringBuilder();
@@ -719,7 +720,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
                    		description = "The Item_ID or block to add to the sellAll Shop.") String itemID,
                    @Arg(name = "Value", description = "The value of the item.") Double value){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ){
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -793,7 +794,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     private void sellAllDeleteCommand(CommandSender sender, 
     		@Arg(name = "Item_ID", description = "The Item_ID you want to remove.") String itemID){
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -824,7 +825,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
                 @Arg(name = "Item_ID", description = "The Item_ID or block to add to the sellAll Shop.") String itemID,
                 @Arg(name = "Value", description = "The value of the item.") Double value){
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -877,7 +878,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     				def = "false") 
     			String isLoreAllowed ){
     	
-    	if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+    	if ( !isEnabled() ) {
     		return;
     	}
     	SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -936,7 +937,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     					+ "columns in the output by using 'cols=16', where the default is 10 columns.  ")
     		String options ) {
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -1144,7 +1145,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
            @Arg(name = "rank", description = "The rank name for the multiplier.") String rank,
            @Arg(name = "multiplier", description = "Multiplier value.") Double multiplier) {
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if (!isEnabled() ) {
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -1168,7 +1169,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     private void sellAllDeleteMultiplierCommand(CommandSender sender,
          @Arg(name = "Rank", description = "The rank name of the multiplier.") String rank){
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -1206,7 +1207,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     		
     		) {
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -1278,7 +1279,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     		
     		) {
     	
-    	if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+    	if ( !isEnabled() ) {
     		return;
     	}
     	SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -1346,7 +1347,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     private void sellAllToolsTriggerToggle(CommandSender sender,
     		@Arg(name = "Boolean", description = "Enable or disable", def = "true") String enable){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if (!isEnabled() ) {
         	return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -1389,7 +1390,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     private void sellAllTriggerAdd(CommandSender sender,
                                    @Arg(name = "Item", description = "Item name") String itemID){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if (!isEnabled() ) {
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -1428,7 +1429,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     private void sellAllTriggerDelete(CommandSender sender,
                                       @Arg(name = "Item", description = "Item name") String itemID){
 
-        if (!isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();
@@ -1466,7 +1467,9 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     		permissions = "prison.admin", onlyPlayers = false)
     private void sellAllSetDefaultCommand(CommandSender sender){
 
-        if (!isEnabled()) return;
+        if ( !isEnabled() ) {
+        	return;
+        }
 
         // Setup all the prices in sellall:
         SpigotPlatform platform = (SpigotPlatform) Prison.get().getPlatform();
@@ -1484,7 +1487,7 @@ public class PrisonSpigotSellAllCommands extends PrisonSpigotBaseCommands {
     		permissions = "prison.admin", onlyPlayers = false)
     private void sellAllListItems( CommandSender sender ) {
 
-        if ( !isEnabled() || !SpigotPrison.getInstance().isSellAllEnabled() ){
+        if ( !isEnabled() ) {
             return;
         }
         SellAllUtil sellAllUtil = SellAllUtil.get();

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/compat/Compatibility.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/compat/Compatibility.java
@@ -21,6 +21,7 @@ package tech.mcprison.prison.spigot.compat;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -39,6 +40,8 @@ public interface Compatibility
 	
 	
     public EquipmentSlot getHand(PlayerInteractEvent e);
+    
+    public EquipmentSlot getHand(BlockPlaceEvent e);
 
     public ItemStack getItemInMainHand(PlayerInteractEvent e);
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/compat/Spigot_1_13.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/compat/Spigot_1_13.java
@@ -4,6 +4,7 @@ import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -25,6 +26,15 @@ public class Spigot_1_13
         }
     }
 
+    @Override 
+    public EquipmentSlot getHand(BlockPlaceEvent e) {
+    	if (e.getHand() == null) {
+    		return null;
+    	} else {
+    		return EquipmentSlot.valueOf(e.getHand().name());
+    	}
+    }
+    
     @Override 
     public ItemStack getItemInMainHand(PlayerInteractEvent e) {
         return getItemInMainHand( e.getPlayer() );

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/compat/Spigot_1_8.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/compat/Spigot_1_8.java
@@ -22,6 +22,7 @@ import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -42,6 +43,11 @@ public class Spigot_1_8
     @Override 
     public EquipmentSlot getHand(PlayerInteractEvent e) {
         return EquipmentSlot.HAND; // Spigot 1.8 only has one hand
+    }
+    
+    @Override 
+    public EquipmentSlot getHand(BlockPlaceEvent e) {
+    	return EquipmentSlot.HAND; // Spigot 1.8 only has one hand
     }
 
 	@Override 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/compat/Spigot_1_9.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/compat/Spigot_1_9.java
@@ -22,6 +22,7 @@ import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -46,6 +47,15 @@ public class Spigot_1_9
         } else {
             return EquipmentSlot.valueOf(e.getHand().name());
         }
+    }
+
+    @Override 
+    public EquipmentSlot getHand(BlockPlaceEvent e) {
+    	if (e.getHand() == null) {
+    		return null;
+    	} else {
+    		return EquipmentSlot.valueOf(e.getHand().name());
+    	}
     }
 
     @Override 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/GuiConfig.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/configs/GuiConfig.java
@@ -204,9 +204,15 @@ public class GuiConfig extends SpigotConfigComponents{
         		
         		map.put("NoMineAccess", XMaterial.REDSTONE_BLOCK.name() );
         				
-        		for ( Mine mine : PrisonMines.getInstance().getMineManager().getMines() ) {
-        			if ( mine.getPrisonBlocks().size() > 0 ) {
-        				map.put( mine.getName(), mine.getPrisonBlocks().get(0).getBlockName() );
+        		
+        		if ( PrisonMines.getInstance().getMineManager() != null && 
+        				PrisonMines.getInstance().getMineManager().getMines() != null && 
+        				PrisonMines.getInstance().getMineManager().getMines().size() > 0 ) {
+        			
+        			for ( Mine mine : PrisonMines.getInstance().getMineManager().getMines() ) {
+        				if ( mine.getPrisonBlocks().size() > 0 ) {
+        					map.put( mine.getName(), mine.getPrisonBlocks().get(0).getBlockName() );
+        				}
         			}
         		}
         		
@@ -232,12 +238,17 @@ public class GuiConfig extends SpigotConfigComponents{
         		
         		map.put("NoRankAccess", XMaterial.REDSTONE_BLOCK.name() );
 
-        		// Example to preset all ranks: Only do the first 10:
-        		int count = 0;
-        		for ( Rank rank : PrisonRanks.getInstance().getRankManager().getRanks() ) {
-        			map.put( rank.getName(), XMaterial.TRIPWIRE_HOOK.name() );
-        			if ( ++count >= 10 ) {
-        				break;
+        		if ( PrisonRanks.getInstance().getRankManager() != null && 
+        				PrisonRanks.getInstance().getRankManager().getRanks() != null &&
+        				PrisonRanks.getInstance().getRankManager().getRanks().size() > 0 ) {
+        			
+        			// Example to preset all ranks: Only do the first 10:
+        			int count = 0;
+        			for ( Rank rank : PrisonRanks.getInstance().getRankManager().getRanks() ) {
+        				map.put( rank.getName(), XMaterial.TRIPWIRE_HOOK.name() );
+        				if ( ++count >= 10 ) {
+        					break;
+        				}
         			}
         		}
         		
@@ -265,8 +276,11 @@ public class GuiConfig extends SpigotConfigComponents{
         
         if ( conf.get( "Options.Mines.GuiItemNames" ) == null ) {
         	
-        	if ( PrisonMines.getInstance() != null ) {
-
+        	if ( PrisonMines.getInstance() != null &&
+        			PrisonMines.getInstance().getMineManager() != null && 
+        				PrisonMines.getInstance().getMineManager().getMines() != null && 
+        				PrisonMines.getInstance().getMineManager().getMines().size() > 0 ) {
+        		
         		LinkedHashMap<String,String> map = new LinkedHashMap<>();
         		
         		// Example to preset all mines: Only do the first 10:
@@ -293,7 +307,10 @@ public class GuiConfig extends SpigotConfigComponents{
         }
         if ( conf.get( "Options.Ranks.GuiItemNames" ) == null ) {
         	
-        	if ( PrisonRanks.getInstance() != null ) {
+        	if ( PrisonRanks.getInstance() != null &&
+        			PrisonRanks.getInstance().getRankManager() != null && 
+    					PrisonRanks.getInstance().getRankManager().getRanks() != null &&
+    						PrisonRanks.getInstance().getRankManager().getRanks().size() > 0 ) {
         		
         		LinkedHashMap<String,String> map = new LinkedHashMap<>();
         		

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/economies/EssEconomyWrapper.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/economies/EssEconomyWrapper.java
@@ -39,7 +39,13 @@ class EssEconomyWrapper {
 
     double getBalance(Player player) {
         try {
-            return Economy.getMoneyExact(player.getName()).doubleValue();
+        	if ( Economy.playerExists( player.getName() ) ) {
+        		return Economy.getMoneyExact(player.getName()).doubleValue();
+        	}
+        	
+        	player.sendMessage( "You don't exist in the economy plugin." );
+        	return 0;
+        	
         } catch (UserDoesNotExistException e) {
             player.sendMessage("You don't exist in the economy plugin.");
             return 0.0;
@@ -48,7 +54,14 @@ class EssEconomyWrapper {
 
     void setBalance(Player player, double amount) {
         try {
-            Economy.setMoney(player.getName(), new BigDecimal(amount));
+           	if ( Economy.playerExists( player.getName() ) ) {
+           		Economy.setMoney(player.getName(), new BigDecimal(amount));
+        	}
+           	else {
+           		
+           		player.sendMessage( "You don't exist in the economy plugin." );
+           	}
+
         } catch (UserDoesNotExistException | NoLoanPermittedException e) {
             player.sendMessage("You don't exist in the economy plugin.");
         }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/economies/SaneEconomyWrapper.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/economies/SaneEconomyWrapper.java
@@ -27,7 +27,15 @@ public class SaneEconomyWrapper
     	double result = 0;
         
     	try {
-    		result = economyManager.getBalance(toEconomablePlayer(player));
+    		EconomablePlayer p = toEconomablePlayer(player);
+    		
+    		if ( !economyManager.accountExists( p ) ) {
+        		player.sendMessage( "Economy Error: You don't have an account.");
+        	}
+        	else {
+        		
+        		result = economyManager.getBalance( p );
+        	}
     	}
 	    catch ( Exception e ) {
 	    	Output.get().logError( "Failed to get SaneEconomy balance. " +
@@ -39,7 +47,16 @@ public class SaneEconomyWrapper
 
     public void setBalance(Player player, double amount) {
     	try {
-    		economyManager.setBalance(toEconomablePlayer(player), amount);
+    		EconomablePlayer p = toEconomablePlayer(player);
+    		
+    		if ( !economyManager.accountExists( p ) ) {
+        		player.sendMessage( "Economy Error: You don't have an account.");
+        	}
+        	else {
+        		
+        		economyManager.setBalance(toEconomablePlayer(player), amount);
+        	}
+    		
     	}
 	    catch ( Exception e ) {
 	    	Output.get().logError( "Failed to set SaneEconomy balance. " +

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/economies/VaultEconomyWrapper.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/economies/VaultEconomyWrapper.java
@@ -110,7 +110,13 @@ public class VaultEconomyWrapper
     @SuppressWarnings( "deprecation" )
 	public double getBalance(Player player) {
     	double results = 0;
+ 
+    	if ( economy != null && !economy.hasAccount( getOfflinePlayer( player ) ) ) {
+    		player.sendMessage( "Economy Error: You don't have an account.");
+    	}
+    	else 
         if (economy != null) {
+        	
         	if ( isPreV1_4() ) {
         		results = economy.getBalance(player.getName());
         	}
@@ -152,6 +158,11 @@ public class VaultEconomyWrapper
     @SuppressWarnings( "deprecation" )
 	public boolean setBalance(Player player, double amount) {
     	boolean results = false;
+
+    	if ( economy != null && !economy.hasAccount( getOfflinePlayer( player ) ) ) {
+    		player.sendMessage( "Economy Error: You don't have an account.");
+    	}
+    	else 
         if (economy != null) {
         	
            	if ( isPreV1_4() ) {
@@ -190,6 +201,10 @@ public class VaultEconomyWrapper
     	
     	if ( amount < 0 ) {
     		results = removeBalance( player, amount );
+    	}
+    	
+    	else if ( economy != null && !economy.hasAccount( getOfflinePlayer( player ) ) ) {
+    		player.sendMessage( "Economy Error: You don't have an account.");
     	}
     	else if (economy != null) {
         	if ( isPreV1_4() ) {
@@ -239,6 +254,10 @@ public class VaultEconomyWrapper
     		amount *= -1;
     	}
     	
+    	if ( economy != null && !economy.hasAccount( getOfflinePlayer( player ) ) ) {
+    		player.sendMessage( "Economy Error: You don't have an account.");
+    	}
+    	else 
     	if (economy != null) {
     		if ( isPreV1_4() ) {
     			economy.withdrawPlayer( player.getName(), amount );
@@ -284,6 +303,11 @@ public class VaultEconomyWrapper
     @SuppressWarnings( "deprecation" )
 	public boolean canAfford(Player player, double amount) {
     	boolean results = false;
+    	
+    	if ( economy != null && !economy.hasAccount( getOfflinePlayer( player ) ) ) {
+    		player.sendMessage( "Economy Error: You don't have an account.");
+    	}
+    	else 
     	if (economy != null) {
        		if ( isPreV1_4() ) {
        			results = economy.has(player.getName(), amount);

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
@@ -29,6 +29,7 @@ import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import tech.mcprison.prison.Prison;
 import tech.mcprison.prison.PrisonAPI;
+import tech.mcprison.prison.commands.CommandHandler;
 import tech.mcprison.prison.integration.PermissionIntegration;
 import tech.mcprison.prison.internal.CommandSender;
 import tech.mcprison.prison.internal.Player;
@@ -68,12 +69,19 @@ public class SpigotCommandSender implements CommandSender {
      * it then uses the mapped command.
      * </p>
      */
-    @Override public void dispatchCommand(String command) {
-    	String registeredCmd = Prison.get().getCommandHandler().findRegisteredCommand( command );
+    @Override 
+    public void dispatchCommand(String command) {
+    	
+    	command = CommandHandler.remapRootCmdIdentifiers( command );
+    	
+    	String registeredCmd = Prison.get().getCommandHandler()
+    					.findRegisteredCommand( command );
+    	
         Bukkit.getServer().dispatchCommand(bukkitSender, registeredCmd);
     }
 
-    @Override public boolean doesSupportColors() {
+    @Override 
+    public boolean doesSupportColors() {
         return (this instanceof ConsoleCommandSender) && Bukkit.getConsoleSender() != null;
     }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
@@ -33,6 +33,8 @@ import tech.mcprison.prison.commands.CommandHandler;
 import tech.mcprison.prison.integration.PermissionIntegration;
 import tech.mcprison.prison.internal.CommandSender;
 import tech.mcprison.prison.internal.Player;
+import tech.mcprison.prison.ranks.PrisonRanks;
+import tech.mcprison.prison.ranks.data.RankPlayer;
 import tech.mcprison.prison.spigot.SpigotPrison;
 import tech.mcprison.prison.spigot.sellall.SellAllUtil;
 import tech.mcprison.prison.util.Text;
@@ -263,6 +265,17 @@ public class SpigotCommandSender
 		}
 		
 		return player;
+	}
+	
+	@Override
+	public RankPlayer getRankPlayer() {
+		RankPlayer rankPlayer = null;
+		
+		if ( PrisonRanks.getInstance().isEnabled() ) {
+			
+			rankPlayer = PrisonRanks.getInstance().getPlayerManager().getPlayer( (Player) this );
+		}
+		return rankPlayer;
 	}
 
 }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
@@ -40,7 +40,8 @@ import tech.mcprison.prison.util.Text;
 /**
  * @author Faizaan A. Datoo
  */
-public class SpigotCommandSender implements CommandSender {
+public class SpigotCommandSender 
+		implements CommandSender {
 
     private org.bukkit.command.CommandSender bukkitSender;
 
@@ -105,6 +106,18 @@ public class SpigotCommandSender implements CommandSender {
         		sendMessage(msg);
         	}
         }
+    }
+    
+    @Override 
+    public void sendMessage(List<String> messages) {
+    	for (String message : messages) {
+    		
+    		String[] msgs = Text.translateAmpColorCodes(message).split( "\\{br\\}" );
+    		for ( String msg : msgs ) {
+    			
+    			sendMessage(msg);
+    		}
+    	}
     }
 
     @Override 
@@ -238,5 +251,18 @@ public class SpigotCommandSender implements CommandSender {
     public org.bukkit.command.CommandSender getWrapper() {
         return bukkitSender;
     }
+
+	@Override
+	public Player getPlatformPlayer() {
+		Player player = null;
+		
+		Optional<Player> oPlayer = Prison.get().getPlatform().getPlayer( getName() );
+		
+		if ( oPlayer.isPresent() ) {
+			player = oPlayer.get();
+		}
+		
+		return player;
+	}
 
 }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotCommandSender.java
@@ -184,6 +184,23 @@ public class SpigotCommandSender implements CommandSender {
 //    	return results;
     }
     
+    @Override
+    public List<String> getSellAllMultiplierListings() {
+    	List<String> results = new ArrayList<>();
+    	
+    	if ( isPlayer() ) {
+    		
+    		SellAllUtil sellall = SpigotPrison.getInstance().getSellAllUtil();
+    		
+    		if ( sellall != null && getWrapper() != null ) {
+    			results.addAll( sellall.getPlayerMultiplierList((org.bukkit.entity.Player) getWrapper()) );
+    		}
+    	}
+
+    	
+    	return results;
+    }
+    
     public List<String> getPermissionsIntegrations( boolean detailed ) {
     	List<String> results = new ArrayList<>();
     	

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotOfflinePlayer.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotOfflinePlayer.java
@@ -20,6 +20,8 @@ import tech.mcprison.prison.internal.scoreboard.Scoreboard;
 import tech.mcprison.prison.output.Output;
 import tech.mcprison.prison.ranks.PrisonRanks;
 import tech.mcprison.prison.ranks.data.RankPlayer;
+import tech.mcprison.prison.spigot.SpigotPrison;
+import tech.mcprison.prison.spigot.sellall.SellAllUtil;
 import tech.mcprison.prison.util.Gamemode;
 import tech.mcprison.prison.util.Location;
 
@@ -316,6 +318,23 @@ public class SpigotOfflinePlayer
 
     		results = sPlayer.getSellAllMultiplier();
     	}
+    	
+    	return results;
+    }
+    
+    
+    public List<String> getSellAllMultiplierListings() {
+    	List<String> results = new ArrayList<>();
+    	
+    	if ( isPlayer() ) {
+    		
+    		SellAllUtil sellall = SpigotPrison.getInstance().getSellAllUtil();
+    		
+    		if ( sellall != null && getWrapper() != null ) {
+    			results.addAll( sellall.getPlayerMultiplierList((org.bukkit.entity.Player) getWrapper()) );
+    		}
+    	}
+
     	
     	return results;
     }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotOfflinePlayer.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotOfflinePlayer.java
@@ -10,6 +10,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 
+import tech.mcprison.prison.Prison;
 import tech.mcprison.prison.cache.PlayerCache;
 import tech.mcprison.prison.cache.PlayerCachePlayerData;
 import tech.mcprison.prison.file.JsonFileIO;
@@ -386,6 +387,25 @@ public class SpigotOfflinePlayer
 	public void incrementMinecraftStatsDropCount( tech.mcprison.prison.internal.Player player, 
 			String blockName, int quantity) {
 		
+	}
+
+	@Override
+	public void sendMessage(List<String> messages) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public tech.mcprison.prison.internal.Player getPlatformPlayer() {
+		tech.mcprison.prison.internal.Player player = null;
+		
+		Optional<tech.mcprison.prison.internal.Player> oPlayer = Prison.get().getPlatform().getPlayer( getName() );
+		
+		if ( oPlayer.isPresent() ) {
+			player = oPlayer.get();
+		}
+		
+		return player;
 	}
 
 }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotPlayer.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotPlayer.java
@@ -668,6 +668,7 @@ public class SpigotPlayer
 		}
 	}
 	
+	@Override
 	public RankPlayer getRankPlayer() {
 		if ( rankPlayer == null && 
 				PrisonRanks.getInstance().isEnabled() ) {

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotPlayer.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotPlayer.java
@@ -669,7 +669,9 @@ public class SpigotPlayer
 	}
 	
 	public RankPlayer getRankPlayer() {
-		if ( rankPlayer == null ) {
+		if ( rankPlayer == null && 
+				PrisonRanks.getInstance().isEnabled() ) {
+			
 			rankPlayer = PrisonRanks.getInstance().getPlayerManager().getPlayer( this );
 		}
 		return rankPlayer;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotPlayer.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/game/SpigotPlayer.java
@@ -854,15 +854,32 @@ public class SpigotPlayer
 	 * autosell capabilities ('/sellall autoSellToggle`).
 	 * </p>
 	 * 
+	 * <p>Please note that for sellall, autosell happens upon a 
+	 * full inventory event, and only when sellall detects it, which
+	 * it may not alway detect it as soon as it happens.
+	 * </p>y
+	 * 
+	 * <p>Autosell in auto features behaves differently, it sells all 
+	 * blocks that are mined, before they even enter the player's 
+	 * inventory.  This is also a performance boost since the player's
+	 * inventory does not have to be accessed or manipulated.  
+	 * As such, auto feature's autsell only is applied within the 
+	 * block handling of auto feature's code, it should never be applied
+	 * outside of auto features, and as such, should not be included in 
+	 * the processing of this function.
+	 * </p>
+	 * 
 	 * @return
 	 */
-	public boolean isAutoSellEnabled() {
-		return isAutoSellEnabled( null );
-	}
+//	public boolean isAutoSellEnabled() {
+//		return isAutoSellEnabled( null );
+//	}
+	
 	public boolean isAutoSellEnabled( StringBuilder debugInfo ) {
 		boolean results = false;
 		
-		if ( SpigotPrison.getInstance().isSellAllEnabled() ) {
+		if ( SpigotPrison.getInstance().isSellAllEnabled() &&
+				SellAllUtil.get().isAutoSellEnabled ) {
 			
 			if ( SellAllUtil.get().isAutoSellPerUserToggleable ) {
 				debugInfo.append( "(sellallEnabled:userToggleable)" );
@@ -873,48 +890,62 @@ public class SpigotPlayer
 						SellAllUtil.get().isSellallPlayerUserToggleEnabled( getWrapper() );
 				
 				if ( debugInfo != null ) {
-					debugInfo.append( Output.get().getColorCodeWarning() );
-					debugInfo.append( 
-							String.format(
-									"(Player toggled %s autosell) ", 
-									isPlayerAutoSellTurnedOn ? "on" : "off" ) );
-					debugInfo.append( Output.get().getColorCodeDebug() );
+					debugInfo.append( "(autosellPlayerToggled: " )
+							 .append( Output.get().getColorCodeWarning() )
+							 .append( isPlayerAutoSellTurnedOn ? "enabled" : "disabled" )
+							 .append( Output.get().getColorCodeDebug() )
+							 .append( ")");
 				}
 				
 				// This will return true (allow autosell) unless players can toggle autosell and they turned it off:
 				// This is to be used with other auto sell setting, but never on it's own:
 				results = isPlayerAutoSellTurnedOn;
 				
+				
+				// if autosell is enabled, then need to check to see if perms permit
+				// it to remain enabled... if not, then set results to false:
+				if ( results ) {
+					results = checkAutoSellTogglePerms( debugInfo );
+				}
+				
 			}
 			else {
-				debugInfo.append( "(sellallEnabled)" );
+				debugInfo.append( "(autosell" )
+	  					 .append( Output.get().getColorCodeWarning() )
+						 .append( "Enabled" )
+						 .append( Output.get().getColorCodeDebug() )
+						 .append( ")" );
 				results = true;
 			}
 			
 		}
 		else {
-			debugInfo.append( "(sellallDisabled)" );
+			debugInfo.append( "(autosell" )
+						.append( Output.get().getColorCodeWarning() )
+						.append( "Disabled" )
+						.append( Output.get().getColorCodeDebug() )
+						.append( ")" );
 		}
 		
 		return results;
 	}
 	
 	
-	/**
-	 * <p>This will check to see if the player has the perms enabled
-	 * for autosell.  
-	 * </p>
-	 * 
-	 * <p>If the function 'isAutoSellEnabled()' has already
-	 * been called, you can also pass that in as a parameter so it does
-	 * not have to be recalculated.
-	 * </p>
-	 * 
-	 * @return
-	 */
-	public boolean isAutoSellByPermEnabled( StringBuilder debugInfo ) {
-		return isAutoSellByPermEnabled( isAutoSellEnabled(), debugInfo );
-	}
+//	/**
+//	 * <p>This will check to see if the player has the perms enabled
+//	 * for autosell.  
+//	 * </p
+//	 * 
+//	 * <p>If the function 'isAutoSellEnabled()' has already
+//	 * been called, you can also pass that in as a parameter so it does
+//	 * not have to be recalculated.
+//	 * </p>
+//	 * 
+//	 * @return
+//	 */
+//	public boolean isAutoSellByPermEnabled( StringBuilder debugInfo ) {
+//		return isAutoSellByPermEnabled( isAutoSellEnabled( debugInfo ), debugInfo );
+//	}
 
 	/**
 	 * <p>This will check to see if the player has the perms enabled
@@ -929,40 +960,105 @@ public class SpigotPlayer
 	 * @param isPlayerAutosellEnabled
 	 * @return
 	 */
-	public boolean isAutoSellByPermEnabled( boolean isPlayerAutosellEnabled, StringBuilder debugInfo ) {
+	private boolean isAutoSellByPermEnabledAutoFeatures( StringBuilder debugInfo ) {
 		
-		boolean autoSellByPerm = false;
+		boolean autoSellByPerm = true;
 		
 		AutoFeaturesWrapper afw = AutoFeaturesWrapper.getInstance();
 		
-		boolean isSellallEnabled = SpigotPrison.getInstance().isSellAllEnabled();
-		
-		if ( isSellallEnabled && isPlayerAutosellEnabled && 
-				afw.isBoolean(AutoFeatures.isAutoSellPerBlockBreakEnabled) ) {
+		if ( afw.isBoolean(AutoFeatures.isAutoSellPerBlockBreakEnabled) ) {
 			
 			String perm = afw.getMessage( AutoFeatures.permissionAutoSellPerBlockBreakEnabled );
 
 			if ( !"disable".equalsIgnoreCase( perm ) &&
 					!"false".equalsIgnoreCase( perm ) ) {
 				
+				debugInfo.append( "(autosellAutoFeaturesByPerm: " )
+				.append( Output.get().getColorCodeWarning() )
+				;
+				
 				if ( isOp() ) {
-					debugInfo.append( "(autosellByPerm:Op-Disabled)" );
+					debugInfo.append( "Op-Disabled" );
+					autoSellByPerm = false;
 				}
 				else {
 					
 					autoSellByPerm = hasPermission( perm );
 					
-					debugInfo.append( 
-							String.format(
-									"(autosellByPerm:%s)",
-									autoSellByPerm ? "hasPerm" : "noPerm") );
+					debugInfo.append( autoSellByPerm ? "hasPerm" : "noPerm" );
 				}
 				
+				debugInfo.append( Output.get().getColorCodeDebug() )
+						.append( ")" );
 			}
-			
 		}
 
 		return autoSellByPerm;
+	}
+	
+	public boolean checkAutoSellPermsAutoFeatures() {
+		boolean results = false;
+		
+		AutoFeaturesWrapper afw = AutoFeaturesWrapper.getInstance();
+		if ( afw.isBoolean(AutoFeatures.isAutoSellPerBlockBreakEnabled) ) {
+			
+			String perm = afw.getMessage( AutoFeatures.permissionAutoSellPerBlockBreakEnabled );
+
+			if ( !"disable".equalsIgnoreCase( perm ) &&
+					!"false".equalsIgnoreCase( perm ) ) {
+				if ( isOp() ) {
+					results = false;
+				}
+				else {
+					
+					results = hasPermission( perm );
+					
+				}
+			}
+		}
+		
+		return results;
+	}
+	
+	/**
+	 * <p>This is using the sellall perms check to see if the player has 
+	 * the perms to use the player toggle.
+	 * </p>
+	 * 
+	 * @return
+	 */
+	public boolean checkAutoSellTogglePerms( StringBuilder debugInfo ) {
+		boolean results = true;
+		
+		if ( SellAllUtil.get().isAutoSellPerUserToggleablePermEnabled ) {
+			
+			debugInfo.append( "(autosellToggleByPerm: " )
+				.append( Output.get().getColorCodeWarning() )
+				;
+			
+			String perm = SellAllUtil.get().permissionAutoSellPerUserToggleable;
+			
+			if ( !"disable".equalsIgnoreCase( perm ) &&
+					!"false".equalsIgnoreCase( perm ) ) {
+				if ( isOp() ) {
+					
+					debugInfo.append( "Op-Disabled" );
+					
+					results = false;
+				}
+				else {
+					
+					results = hasPermission( perm );
+					
+					debugInfo.append( results ? "hasPerm" : "noPerm" );
+				}
+			}
+			
+			debugInfo.append( Output.get().getColorCodeDebug() )
+					 .append( ")" );
+		}
+		
+		return results;
 	}
 
 }

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/gui/ListenersPrisonManager.java
@@ -263,7 +263,10 @@ public class ListenersPrisonManager
                             if (sign.getLine(0).equalsIgnoreCase(SpigotPrison.format(signTag))) {
                                 String permissionUseSign = sellAllUtil.permissionUseSign;
                                 if (sellAllUtil.isSellAllSignPermissionToUseEnabled && !p.hasPermission(permissionUseSign)) {
-                                    Output.get().sendWarn(new SpigotPlayer(p), messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) + " [&3" + permissionUseSign + "&7]");
+                                    Output.get().sendWarn(new SpigotPlayer(p), 
+                                    		messages.getString(MessagesConfig.StringID.spigot_message_missing_permission) 
+//                                    		+ " [&3" + permissionUseSign + "&7]"
+                                    		);
                                     return;
                                 }
 

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/nbt/PrisonNBTUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/nbt/PrisonNBTUtil.java
@@ -2,11 +2,14 @@ package tech.mcprison.prison.spigot.nbt;
 
 import java.util.function.Function;
 
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
 
 import de.tr7zw.changeme.nbtapi.NBT;
 import de.tr7zw.changeme.nbtapi.iface.ReadWriteNBT;
 import de.tr7zw.changeme.nbtapi.iface.ReadableItemNBT;
+import de.tr7zw.changeme.nbtapi.iface.ReadableNBT;
 import tech.mcprison.prison.output.Output;
 
 /**
@@ -47,6 +50,18 @@ public class PrisonNBTUtil {
 		
 		results = NBT.get(bukkitStack, gsFnc );
 //		results = NBT.get(bukkitStack, nbt -> nbt.getString(key));
+		
+		return results;
+	}
+	
+	public static String getNBTString( Block bukkitBlock, String key ) {
+		String results = null;
+		
+		Function<ReadableNBT, String> gsFnc = nbt -> nbt.getString(key);
+		
+		BlockState blockState = bukkitBlock.getState();
+		
+		results = NBT.get(blockState, gsFnc );
 		
 		return results;
 	}
@@ -108,9 +123,18 @@ public class PrisonNBTUtil {
 		}
 	}
 	
+	
 	public static String nbtDebugString( ItemStack bukkitStack ) {
 		
 		ReadWriteNBT nbtItem = NBT.itemStackToNBT(bukkitStack);
+		return nbtItem.toString();
+	}
+	
+	public static String nbtDebugString() {
+		
+		ReadWriteNBT nbtItem = NBT.createNBTObject();
+		
+//		ReadWriteNBT nbtItem = NBT.itemStackToNBT(bukkitStack);
 		return nbtItem.toString();
 	}
 	

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllUtil.java
@@ -1076,49 +1076,49 @@ public class SellAllUtil
 //        return xMaterialIntegerHashMap;
 //    }
 
-    /**
-     * If autosell is enabled, and if user toggleable is enabled, then
-     * it will check to see if the player has the perm or 
-     * 
-     * Get AutoSell Player toggle if available.
-     * If he enabled it, AutoSell will work, otherwise it won't.
-     * If he never used the toggle command, this will return true, just like if he enabled it in the first place.
-     *
-     * @param p - Player.
-     *
-     * @return boolean.
-     * */
-    public boolean isPlayerAutoSellEnabled(Player p){
-    	boolean results = false;
-    	
-    	// If autosell isn't enabled, then return false
-    	if ( isAutoSellEnabled ) {
-    		
-    		results =  isSellallPlayerUserToggleEnabled( p );
-//    		if ( !isAutoSellPerUserToggleablePermEnabled ||
-//    			 isAutoSellPerUserToggleablePermEnabled && 
-//    				p.hasPermission(permissionAutoSellPerUserToggleable)){
-//    			
-//    			String settingName = "Users." + p.getUniqueId() + ".isEnabled";
-//    			
-//    			results = sellAllConfig.getString(settingName) == null ||
-//    					getBooleanValue( settingName );
-//    		}
-    	}
-    		
-    	
-//        if (isAutoSellPerUserToggleablePermEnabled && 
-//        		!p.hasPermission(permissionAutoSellPerUserToggleable)){
-//            return false;
-//        }
+//    /**
+//     * If autosell is enabled, and if user toggleable is enabled, then
+//     * it will check to see if the player has the perm or 
+//     * 
+//     * Get AutoSell Player toggle if available.
+//     * If he enabled it, AutoSell will work, otherwise it won't.
+//     * If he never used the toggle command, this will return true, just like if he enabled it in the first place.
+//     *
+//     * @param p - Player.
+//     *
+//     * @return boolean.
+//     * */
+//    public boolean isPlayerAutoSellEnabled(Player p){
+//    	boolean results = false;
+//    	
+//    	// If autosell isn't enabled, then return false
+//    	if ( isAutoSellEnabled ) {
+//    		
+//    		results =  isSellallPlayerUserToggleEnabled( p );
+////    		if ( !isAutoSellPerUserToggleablePermEnabled ||
+////    			 isAutoSellPerUserToggleablePermEnabled && 
+////    				p.hasPermission(permissionAutoSellPerUserToggleable)){
+////    			
+////    			String settingName = "Users." + p.getUniqueId() + ".isEnabled";
+////    			
+////    			results = sellAllConfig.getString(settingName) == null ||
+////    					getBooleanValue( settingName );
+////    		}
+//    	}
+//    		
+//    	
+////        if (isAutoSellPerUserToggleablePermEnabled && 
+////        		!p.hasPermission(permissionAutoSellPerUserToggleable)){
+////            return false;
+////        }
+////
+////        if (sellAllConfig.getString("Users." + p.getUniqueId() + ".isEnabled") == null){
+////            return true;
+////        }
 //
-//        if (sellAllConfig.getString("Users." + p.getUniqueId() + ".isEnabled") == null){
-//            return true;
-//        }
-
-//        return getBooleanValue("Users." + p.getUniqueId() + ".isEnabled");
-	    return results;
-    }
+////        return getBooleanValue("Users." + p.getUniqueId() + ".isEnabled");
+//	    return results;
+//    }
     
     /**
      * <p>This function only checks to see if the user can toggle autosell
@@ -1135,17 +1135,21 @@ public class SellAllUtil
     public boolean isSellallPlayerUserToggleEnabled( Player p ) {
     	boolean results = false;
     	
-    	if ( isAutoSellPerUserToggleable ) {
+    	// If autosell isn't enabled, then return false
+    	if ( isAutoSellEnabled ) {
     		
-    		if ( !isAutoSellPerUserToggleablePermEnabled ||
-       			 isAutoSellPerUserToggleablePermEnabled && 
-       				p.hasPermission(permissionAutoSellPerUserToggleable)){
-       			
-       			String settingName = "Users." + p.getUniqueId() + ".isEnabled";
-       			
-       			results = sellAllConfig.getString( settingName ) == null ||
-       					getBooleanValue( settingName );
-       		}
+    		if ( isAutoSellPerUserToggleable ) {
+    			
+    			if ( !isAutoSellPerUserToggleablePermEnabled ||
+    					isAutoSellPerUserToggleablePermEnabled && 
+    					p.hasPermission(permissionAutoSellPerUserToggleable)){
+    				
+    				String settingName = "Users." + p.getUniqueId() + ".isEnabled";
+    				
+    				results = sellAllConfig.getString( settingName ) == null ||
+    						getBooleanValue( settingName );
+    			}
+    		}
     	}
     	
     	return results;

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonBombListener.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonBombListener.java
@@ -4,11 +4,14 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
@@ -51,6 +54,44 @@ public class PrisonBombListener
 		
 		this.blockBreakMines = new OnBlockBreakMines();
 	}
+	
+	@EventHandler( priority = EventPriority.LOW )
+	public void onInteract( BlockPlaceEvent event ) {
+		
+    	String bombName = PrisonNBTUtil.getNBTString( event.getBlockPlaced(), 
+    			MineBombs.MINE_BOMBS_NBT_BOMB_KEY );
+    	
+    	if ( bombName == null || bombName.trim().length() == 0 ) {
+//    	if ( !nbtItem.hasKey( MineBombs.MINE_BOMBS_NBT_BOMB_KEY ) ) {
+    		return;
+    	}
+
+    	if ( Output.get().isDebug() ) {
+    		Output.get().logInfo( "PrisonBombListener.onInteract (block) "
+    				+ "bombName: &7%s&r &3::  nbt: &r%s", 
+    				bombName, 
+    				PrisonNBTUtil.nbtDebugString( )
+//    				PrisonNBTUtil.nbtDebugString( event.getBlockPlaced() )
+//    				(nbtItem == null ? "&a-no-nbt-" : nbtItem.toString()) 
+    				);
+    		
+
+    		Player player = event.getPlayer();
+           	
+        	Block targetBlock = event.getBlockAgainst();
+        	
+        	EquipmentSlot hand = SpigotCompatibility.getInstance().getHand(event);
+        	
+        	boolean canceled = processBombTriggerEvent(event, player, bombName, 
+        			targetBlock, hand );
+
+        	if ( canceled ) {
+        		event.setCancelled( canceled );
+        	}
+
+    	}
+       
+	}
 
     @EventHandler( priority = EventPriority.LOW )
     public void onInteract( PlayerInteractEvent event ) {
@@ -84,7 +125,8 @@ public class PrisonBombListener
 //        	String bombName = nbtItem.getString( MineBombs.MINE_BOMBS_NBT_BOMB_KEY );
         	
         	if ( Output.get().isDebug() ) {
-        		Output.get().logInfo( "PrisonBombListener.onInteract bombName: &7%s&r &3::  nbt: &r%s", 
+        		Output.get().logInfo( "PrisonBombListener.onInteract (item) "
+        				+ "bombName: &7%s&r &3::  nbt: &r%s", 
         				bombName, 
         				PrisonNBTUtil.nbtDebugString( event.getItem() )
 //        				(nbtItem == null ? "&a-no-nbt-" : nbtItem.toString()) 
@@ -93,6 +135,27 @@ public class PrisonBombListener
         	
         	Player player = event.getPlayer();
         	
+        	Block targetBlock = event.getClickedBlock();
+        	
+        	EquipmentSlot hand = SpigotCompatibility.getInstance().getHand(event);
+        	
+        	boolean canceled = processBombTriggerEvent(event, player, bombName, 
+        			targetBlock, hand );
+        	
+        	if ( canceled ) {
+        		event.setCancelled( canceled );
+        	}
+        	
+        }
+    }
+
+	private boolean processBombTriggerEvent( Event event, Player player, 
+					String bombName, Block targetBlock,
+					EquipmentSlot hand ) {
+		
+		boolean canceled = false;
+		
+		
 //        	// Temp test stuff... remove when NBTs are working:
 //        	{
 //        		
@@ -110,95 +173,97 @@ public class PrisonBombListener
 //        		SpigotItemStack sItemStack = new SpigotItemStack( event.getItem() );
 //        		Output.get().logInfo( sItemStack.getNBT().toString() );
 //        	}
-        	
-        	MineBombData bomb = getPrisonUtilsMineBombs().getBombItem( bombName );
-        	
-        	
-        	if ( bomb == null ) {
-            	if ( Output.get().isDebug() ) {
-        			Output.get().logInfo( "MineBombs: The bomb named '%s' cannot be mapped to a mine bomb.",
-        					bombName );
-        		}
-        		return;
-        	}
-        	
-        	SpigotBlock sBlock = null;
-        	
-        	SpigotPlayer sPlayer = new SpigotPlayer( player );
-        	
-        	// If clicking AIR, then event.getClickedBlock() will be null...
-        	// so if null, then use the player's location for placing the bomb.
-        	if ( event.getClickedBlock() == null ) {
-        		Location loc = sPlayer.getLocation();
-        		
-        		// Get the block 3 away from the player, in the direction (vector) in which
-        		// the player is looking.
-        		sBlock = (SpigotBlock) loc.add( loc.getDirection().multiply( 3 ) ) .getBlockAt();
-        	}
-        	else {
-        		sBlock = SpigotBlock.getSpigotBlock( event.getClickedBlock() );
-        	}
-        	
-        	
-        	Mine mine = blockBreakMines.findMine(player, sBlock, null, null);
-        	if ( mine == null ) {
-        		// player is not in a mine, so do not allow them to trigger a mine bomb:
-        		
-        		if ( Output.get().isDebug() ) {
-        			Output.get().logInfo( "MineBombs: Cannot mine bombs use outside of mines." );
-        		}
-        		
-        		event.setCancelled( true );
-        		return;
-        	}
-        	else if ( !mine.hasMiningAccess( sPlayer ) ) {
-        		// Player does not have access to the mine, so don't allow them to trigger a mine bomb:
-        		
-        		if ( Output.get().isDebug() ) {
-        			Output.get().logInfo( "MineBombs: Player %s&r does not have access to Mine %s&r.",
-        					sPlayer.getName(), mine.getName());
-        		}
-        		
-        		event.setCancelled( true );
-        		return;
-        	}
-        	
-        	HashSet<String> allowedMines = new HashSet<>( bomb.getAllowedMines() );
-        	HashSet<String> preventedMines = new HashSet<>( bomb.getPreventedMines() );
-        	List<String> globalPreventedMines = (List<String>) Prison.get().getPlatform()
-        			.getConfigStringArray("prison-mines.mine-bombs.prevent-usage-in-mines");
-        	preventedMines.addAll( globalPreventedMines );
-        	
-        	// Skip prevent-in-mines check if mine is within the allowedMines list:
-        	if ( !allowedMines.contains( mine.getName().toLowerCase() ) ) {
-        		
-        		if ( preventedMines.contains( mine.getName().toLowerCase() ) ) {
-        			
-        			// Mine bombs are not allowed to be used in this mine so cancel:
-        			event.setCancelled( true );
-        			return;
-        		}
-        	}
+		
+		MineBombData bomb = getPrisonUtilsMineBombs().getBombItem( bombName );
+		
+		
+		if ( bomb == null ) {
+			if ( Output.get().isDebug() ) {
+				Output.get().logInfo( "MineBombs: The bomb named '%s' cannot be mapped to a mine bomb.",
+						bombName );
+			}
+			return canceled;
+		}
+		
+		SpigotBlock sBlock = null;
+		
+		SpigotPlayer sPlayer = new SpigotPlayer( player );
+		
+		// If clicking AIR, then event.getClickedBlock() will be null...
+		// so if null, then use the player's location for placing the bomb.
+		if ( targetBlock == null ) {
+			Location loc = sPlayer.getLocation();
+			
+			// Get the block 3 away from the player, in the direction (vector) in which
+			// the player is looking.
+			sBlock = (SpigotBlock) loc.add( loc.getDirection().multiply( 3 ) ) .getBlockAt();
+		}
+		else {
+			sBlock = SpigotBlock.getSpigotBlock( targetBlock );
+		}
+		
+		
+		Mine mine = blockBreakMines.findMine(player, sBlock, null, null);
+		if ( mine == null ) {
+			// player is not in a mine, so do not allow them to trigger a mine bomb:
+			
+			if ( Output.get().isDebug() ) {
+				Output.get().logInfo( "MineBombs: Cannot mine bombs use outside of mines." );
+			}
+			
+			canceled = true;
+//			event.setCancelled( true );
+			return canceled;
+		}
+		else if ( !mine.hasMiningAccess( sPlayer ) ) {
+			// Player does not have access to the mine, so don't allow them to trigger a mine bomb:
+			
+			if ( Output.get().isDebug() ) {
+				Output.get().logInfo( "MineBombs: Player %s&r does not have access to Mine %s&r.",
+						sPlayer.getName(), mine.getName());
+			}
+			
+			canceled = true;
+//			event.setCancelled( true );
+			return canceled;
+		}
+		
+		HashSet<String> allowedMines = new HashSet<>( bomb.getAllowedMines() );
+		HashSet<String> preventedMines = new HashSet<>( bomb.getPreventedMines() );
+		List<String> globalPreventedMines = (List<String>) Prison.get().getPlatform()
+				.getConfigStringArray("prison-mines.mine-bombs.prevent-usage-in-mines");
+		preventedMines.addAll( globalPreventedMines );
+		
+		// Skip prevent-in-mines check if mine is within the allowedMines list:
+		if ( !allowedMines.contains( mine.getName().toLowerCase() ) ) {
+			
+			if ( preventedMines.contains( mine.getName().toLowerCase() ) ) {
+				
+				// Mine bombs are not allowed to be used in this mine so cancel:
+				canceled = true;
+//				event.setCancelled( true );
+				return canceled;
+			}
+		}
 
-        	
-        	// getHand() is not available with bukkit 1.8.8 so use the compatibility functions:
-        	EquipmentSlot hand = SpigotCompatibility.getInstance().getHand(event);
+		
+		// getHand() is not available with bukkit 1.8.8 so use the compatibility functions:
+//		EquipmentSlot hand = SpigotCompatibility.getInstance().getHand(event);
 //        	EquipmentSlot hand = event.getHand();
-        	
+		
 //        	Output.get().logInfo( "### PrisonBombListener: PlayerInteractEvent  02 " );
-        	if ( getPrisonUtilsMineBombs().setBombInHand( player, bomb, sBlock, hand ) ) {
-        		
-        		// The item was a bomb and it was activated.
-        		// Cancel the event so the item will not be placed or processed farther.
-        		
+		if ( getPrisonUtilsMineBombs().setBombInHand( player, bomb, sBlock, hand ) ) {
+			
+			// The item was a bomb and it was activated.
+			// Cancel the event so the item will not be placed or processed farther.
+			
 //        		Output.get().logInfo( "### PrisonBombListener: PlayerInteractEvent  03 Bomb detected - May not have been set. " );
-        		event.setCancelled( true );
-        	}
-        	
-        	
-        	
-        }
-    }
+			canceled = true;
+//			event.setCancelled( true );
+		}
+		
+		return canceled;
+	}
     
 
 //    @EventHandler( priority = EventPriority.HIGHEST, ignoreCancelled = false )

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonBombListener.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/utils/PrisonBombListener.java
@@ -14,6 +14,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
 
 import tech.mcprison.prison.Prison;
 import tech.mcprison.prison.bombs.MineBombData;
@@ -58,39 +59,31 @@ public class PrisonBombListener
 	@EventHandler( priority = EventPriority.LOW )
 	public void onInteract( BlockPlaceEvent event ) {
 		
-    	String bombName = PrisonNBTUtil.getNBTString( event.getBlockPlaced(), 
-    			MineBombs.MINE_BOMBS_NBT_BOMB_KEY );
-    	
-    	if ( bombName == null || bombName.trim().length() == 0 ) {
-//    	if ( !nbtItem.hasKey( MineBombs.MINE_BOMBS_NBT_BOMB_KEY ) ) {
-    		return;
-    	}
-
-    	if ( Output.get().isDebug() ) {
-    		Output.get().logInfo( "PrisonBombListener.onInteract (block) "
-    				+ "bombName: &7%s&r &3::  nbt: &r%s", 
-    				bombName, 
-    				PrisonNBTUtil.nbtDebugString( )
-//    				PrisonNBTUtil.nbtDebugString( event.getBlockPlaced() )
-//    				(nbtItem == null ? "&a-no-nbt-" : nbtItem.toString()) 
-    				);
-    		
-
-    		Player player = event.getPlayer();
-           	
-        	Block targetBlock = event.getBlockAgainst();
+		ItemStack iStack = event.getItemInHand();
+		
+		if ( iStack.getType() != Material.AIR ) {
+			
         	
-        	EquipmentSlot hand = SpigotCompatibility.getInstance().getHand(event);
+        	String bombName = checkMineBombItemStack( iStack );
         	
-        	boolean canceled = processBombTriggerEvent(event, player, bombName, 
-        			targetBlock, hand );
-
-        	if ( canceled ) {
-        		event.setCancelled( canceled );
+        	if ( bombName != null ) {
+        		
+        		Player player = event.getPlayer();
+        		
+        		Block targetBlock = event.getBlockAgainst();
+        		
+        		EquipmentSlot hand = SpigotCompatibility.getInstance().getHand(event);
+        		
+        		boolean canceled = processBombTriggerEvent(event, player, bombName, 
+        				targetBlock, hand );
+        		
+        		if ( canceled ) {
+        			event.setCancelled( canceled );
+        		}
         	}
-
-    	}
-       
+			
+		}
+		
 	}
 
     @EventHandler( priority = EventPriority.LOW )
@@ -109,45 +102,57 @@ public class PrisonBombListener
         	// If the player is holding a mine bomb, then get the bomb and decrease the
         	// ItemStack in the player's hand by 1:
         	
+        	ItemStack iStack = event.getItem();
         	
-        	// Check to see if this is an mine bomb by checking the NBT key-value pair,
-        	// which will also identify which mine bomb it is too.
-        	// NOTE: Because we're just checking, do not auto update the itemstack.
-//        	NBTItem nbtItem = new NBTItem( event.getItem() );
+        	String bombName = checkMineBombItemStack( iStack );
         	
-        	String bombName = PrisonNBTUtil.getNBTString( event.getItem(), MineBombs.MINE_BOMBS_NBT_BOMB_KEY );
-        	
-        	if ( bombName == null || bombName.trim().length() == 0 ) {
-//        	if ( !nbtItem.hasKey( MineBombs.MINE_BOMBS_NBT_BOMB_KEY ) ) {
-        		return;
-        	}
-        	
-//        	String bombName = nbtItem.getString( MineBombs.MINE_BOMBS_NBT_BOMB_KEY );
-        	
-        	if ( Output.get().isDebug() ) {
-        		Output.get().logInfo( "PrisonBombListener.onInteract (item) "
-        				+ "bombName: &7%s&r &3::  nbt: &r%s", 
-        				bombName, 
-        				PrisonNBTUtil.nbtDebugString( event.getItem() )
-//        				(nbtItem == null ? "&a-no-nbt-" : nbtItem.toString()) 
-        				);
-        	}
-        	
-        	Player player = event.getPlayer();
-        	
-        	Block targetBlock = event.getClickedBlock();
-        	
-        	EquipmentSlot hand = SpigotCompatibility.getInstance().getHand(event);
-        	
-        	boolean canceled = processBombTriggerEvent(event, player, bombName, 
-        			targetBlock, hand );
-        	
-        	if ( canceled ) {
-        		event.setCancelled( canceled );
+        	if ( bombName != null ) {
+        		
+        		Player player = event.getPlayer();
+        		
+        		Block targetBlock = event.getClickedBlock();
+        		
+        		EquipmentSlot hand = SpigotCompatibility.getInstance().getHand(event);
+        		
+        		boolean canceled = processBombTriggerEvent(event, player, bombName, 
+        				targetBlock, hand );
+        		
+        		if ( canceled ) {
+        			event.setCancelled( canceled );
+        		}
+
+        		
         	}
         	
         }
     }
+
+	private String checkMineBombItemStack( ItemStack iStack ) {
+		// Check to see if this is an mine bomb by checking the NBT key-value pair,
+		// which will also identify which mine bomb it is too.
+		// NOTE: Because we're just checking, do not auto update the itemstack.
+//        	NBTItem nbtItem = new NBTItem( event.getItem() );
+		
+		String bombName = PrisonNBTUtil.getNBTString( iStack, MineBombs.MINE_BOMBS_NBT_BOMB_KEY );
+		
+		if ( bombName != null && bombName.trim().length() == 0 ) {
+			bombName = null;
+		}
+		else if ( bombName != null ){
+			
+			if ( Output.get().isDebug() ) {
+				Output.get().logInfo( "PrisonBombListener.onInteract (item) "
+						+ "bombName: &7%s&r &3::  nbt: &r%s", 
+						bombName, 
+						PrisonNBTUtil.nbtDebugString( iStack )
+//        				(nbtItem == null ? "&a-no-nbt-" : nbtItem.toString()) 
+						);
+			}
+		}
+		
+
+		return bombName;
+	}
 
 	private boolean processBombTriggerEvent( Event event, Player player, 
 					String bombName, Block targetBlock,

--- a/prison-spigot/src/main/resources/config.yml
+++ b/prison-spigot/src/main/resources/config.yml
@@ -274,10 +274,18 @@ number-format-location: en_US
 
 
 # The storage engine that Prison should use to store data.
-# The only valid storageType is json. 
-storageType: "json"
+# The only valid storageType is file. 
+storageType: "file"
 
 
+# The following is experimental and should only be used if advised by a 
+# Prison support team member.
+# 
+storage:
+  file:
+    disable-advanced-saves:
+      enabled: false
+      debug-keep-temp-files: false
 
 
 # Prison mines reset gap is the number of milliseconds that are used to 

--- a/prison-spigot/src/main/resources/config.yml
+++ b/prison-spigot/src/main/resources/config.yml
@@ -479,6 +479,12 @@ prisonCommandHandler:
   exclude-worlds:
   - miniGameWorld
   - playerPlotWorld
+  command-roots:
+    prison: prison
+    mines: mines
+    ranks: ranks
+    gui: gui
+    sellall: sellall
   disable-player-placeholders-in-excluded-worlds: false
   exclude-non-ops:
     exclude-related-aliases: true


### PR DESCRIPTION
Pull request for v3.3.0-alpha.17


The following is a highlight of changes for the alpha.17 release since the alpha.16 release.


* Mines: Added more support for the use of '*all*' for mine names so more of the mine commands will be able to apply to all mines.


* **Upgrade XSeries to v9.7.0 from v9.4.0.**
* **Upgrade XSeries from v9.7.0 to v9.8.0.**
* **XSeries: Upgrade from v9.8.0 to v9.9.0**

* **Upgrade nbt-api from v2.12.0 to v2.12.2.**

* **PlaceholderAPI: Upgrade from v2.11.2 to v2.11.5**



* **Breaking change in XSeries: GRASS has been changed to SHORT_GRASS for v20.0.4!** It's disappointing to say the least that after all of these years, XSeries screwed up and pushed a breaking change to their repo.  They should have kept GRASS so they would have remained compatible will all past code and configs that had to refer to GRASS directly, but nope... they opted for causing problems.  Very disappointing.
Setup a converter to automatically convert all GRASS to SHORT_GRASS as the mines are loaded.



* **Bug Fix: Mine resets and block constraints.**
This fixes a few issues with block constrains using min and max, along with exclude from top and bottom too.


* **Bug Fix: GUI ranks, mines, and prestiges were not using the default item name correctly.**  It was using the template correctly, but was not translating the use of placeholders.  Only name and tag are supported.
Mines: `{mineName}` and `{mineTag}`
Ranks and prestiges: `{rankName}` and `{rankTag}`



* **config.yml - changed the default values for remapping aliases and restricting players from using commands.**
The default, which used `/mines tp` was actually causing conflict with normal usage.


* **AutoFeatures auto permissions: enable the ability to 'disable' the perms.**  Any op'd player, if perms are enabled, will have these auto features enabled.  There is no other way around this, since this is the correct behavior of OP'd players.


* **Mine resets: If a mine reset takes longer than 4 minutes, then that is probably a failure and the mine reset did not complete.**  Therefore, reset the mine reset mutex and try again.  This allows a "crashed" mine reset to auto fix itself if it can.  The 4 minute wait time is LONG, but it will prevent a normal reset from being canceled and restarted in the middle of a restart.


* **Performance: Changed the defaults for the mine reset settings to help improve the performance on larger servers.**
The older settings would allow other commands to backup and it would appear as if there was lag happening, TPS would rarely drop below 20.  This helps to keep performance a little more responsive. 
The side effect is that there will need to be more "chunks" submitted which could possibly result in longer wall-time for mine resets.


* **Mine resets: If a suggested block is null, then set it to air.  This was causing an NPE under some conditions.**


* **BlockEvents: Added the ability to update block events**
instead of deleting them and re-adding them.  Follow directions when using '/mines blockevent update help', or whenever a block event listing is shown in game, you can now click on the commands to auto populate the block event update command... then just edit the needed changes and submit.



* **Mines: Fixes an issue for when mines are disabled and they are being checked in other processes to see if they are active.**
If the instance of PrisonMines is null, then it will create a temp instance just to prevent an NPE.



* **Prison Block change: Add support for display name, which is optional.**
Setup sellall so it can use the display name now, so renamed items will not be mistaken for vanilla minecraft items.
More work needs to be done to hook up displayName to other features, such as sellall and add prison block to mines.


* **Bug fix: Fixed the command `/mines set accessPermission` where it was apply the given perm to all mines.**
 Likewise, all mines parameter was failing to do anything.


* **NOTE: This alpha version "should" support spigot 20.0.4.**
After a few days, if no other issues surface pertaining to 20.0.4, or other related plugins, this will be released as a public release.


* **Fix issue with BlockEvent's SellAll when isAutoSellIfInventoryIsFullForBLOCKEVENTSPriority feature is enabled.**
This was not using the correct new functions that checks to see if a player can use autsell, or if they have it temporarily toggled off.  This also checks to see if the player has the correct perms, if perms are enabled for the sellall event.




* **alpha.16a - 2023-12-28**
  NOTE: I just noticed that alpha.16a was never committed.  So this is not the correct location of when it was set with the local builds.
  


* **updated the help on the `/mines block constraint` to indicate that the layer count is originating from the top, not the bottom.**


* **Bug fix: Player manager startup: fixed a problem where all players were being updated** even though they did not have a name change.  Only when name changes are detected are the files updated or when a new player is found.


* **Mines set resetTime: fix typo in the description where it shows '*all' instead of '*all*'.**


* **ranks ladder: applyRanksCostMultiplier command was changed to allow the value of 'true' to be used along with the value of 'apply'.**  This helps to eliminate some confusion on how the command works.


* **Bug fix: Prison command handler.  When players are de-op'd, and they do the commands such as `/ranks help` or `/mines help` it was incorrectly showing other sub commands they did not have access to.**
This now shows the correct sub commands that they have access to.


* **Placeholders: topn players - bug fix.  If a player did not have a prestige rank, then it would cause a NPE when using the `prison_top_player_rank_prestiges_nnn_tp` placeholder.**
Just check to ensure its not null... if it is, then return an empty string.



* **Bug fix: prison support submit: if the bukkit system cannot extract a file from the jar**, such as plugin.yml, this will prevent the failure of the command.  This will allow the command to continue being processed, but may just skip the extraction.



* **Placeholders: Top player rank was using the wrong ladder, which was incorrectly the prestiges rank and not the default rank.**
Correcting the rank fixed the problem.  This only was an issue if the player did not have a prestige rank.



* **Bug fix: GUI configuration: Found a problem that when configuring the gui initial settings, that there were problems when trying to access mines and ranks when they don't yet exist.**




* **File saving: alternative technique for saving files. Do not use!**
This is a more dangerous technique that could possibly result in lost configurations.  This is being provided as a degraded service if the fail-safe technique is not working ideally on a degraded server.
This should never be used, unless directed by a prison support admin.



* **Prison startup bug: There was an issue with the prison startup when there was an error and prison tried to log the error**, only to find that resources that were needed for logging were not yet loaded nor were their dependencies.  This fixes some of the entanglements to allow the error messages to be properly logged.



* **Import Mines: Added the ability to import mines from JetPrisonMines config files.**
`/mines import jetprisonmines help`


* **Prison Command Handler: using config.yml you can now change all of prison's root commands with 'prisonCommandHandler.command-roots'.**
Can now map 'prison', 'mines', 'ranks', 'gui', 'sellall' to all new command that you want.




**3.3.0-alpha.16b 2024-02-24** 



* **Mine imports: Fix some minor issues to get this to work even better.**

* **Mines import: prevent the processing of an importing of a mine if there are problems with the mine's name, or locations.**



* **Mine skip reset: If a mine is reset, send a message to players, but only if the message is defined and not empty: 'skip_reset_message='**



* **Player sellall Multipliers: Fixed the ranks multiplier to include all ranks that are defined within the sellall multipliers.**
Added a new function that will gather and list all multipliers that go in to the calculation of the player's total multipliers, which includes the rank multipliers (the sellall multipliers) and also permission based multipliers.
This detailed list of the individual multipliers, is viewable for each player that is online with the command `/ranks player <player>` and reveals the actual details of how it's calculated.



* **AutoSell: Bug fix: When autosell and sell on inventory is full was all turned off, it would still sell.**
This fixes some of the logic to simplify the code, and to fix those issues.


* **Mine skip reset messaging: Did not have it hooked up in the correct location, so the skip messages were not happening.**


* **Mine reset: Under heavy load when performing a mine import, there were seen occasionally errors with concurrent modification errors.**
Code was changed to minimize that possibility.


* **Sellall and GUI message failures: a number of messages that would indicate the player does not have access to that command were changed to remove the permission from the message.**
This was requested by a couple of admins because they did not want the players to see the internal workings that would otherwise control how the software would behave.



* **Block lists: Added the total chance percentage to be displayed with the blocks.**


* **File output technique: Changes to how the "replace" existing files works.**
If the file does not exist, then it opens it to create it, otherwise it truncates it.


* **Mine bombs: Ability to prevent a bomb's blocks from count towards the player's block totals.**


* **Sellall and autosell: Refinements were made to the handling of the sellall settings to better stabilize the use of the commands.**  Setting status for the players were moved to the player objects and is now used in all of the related calculations so there is better stability and consistency.



* **Bug fix: the check for the time the reset has been going on was incorrect and was fixed.**
Also all the code for submitting the reset task was moved in to the mutext.  Now, if the reset got hung up, this will properly terminate it and resubmit it.


* **File format: Eliminate the check for file types since there is only one.**
Currently there isn't a setting to specify what it should be.


* **Mines block layerStats: Added a new command that shows which blocks are in each layer in the mine.**
There are a lot of future enhancements that can be added to this command, such as checking the actual blocks to see if they are still there, or if there was a problem with the spawning of the blocks.


* **Mines block layer: Added colors for same IDs so it's easier to read.**  Added a check that sees what block actually exists.  If counts of what should have spawned match whats in the mine for that layer, then it shows only one number.  It shows two numbers if a block's intended spawn does not match what's in the mine.


* **Mine reset: added a force to the reset so it will ignore an existing mine reset and allow a new one to begin.***
When a mine is being reset, there is no way to actually cancel it.  So this allows a large mine to undergo multiple concurrent resets.  Use at your own risk.



* **Mine resets: Reworked how prison is selecting random blocks per layer, to properly include constraints.**
The addition of various new features in the past made a mess of the logic, so it's been cleaned up greatly so it now makes sense and should work properly now.
There is a slight risk, that as blocks are removed from a layer due to reaching it's max constraint value, that future random selections were missing blocks selections and was then inserting AIR. This fixed code now will insert a filler block which has been selected with no constraints, and the largest chance value.


* **mines block layerStats: rewrote to improve and get rid of the collection manipulations.**
Found potential problem with air being inserted in to mines.
Renamed a lot of uses of Location objects to include the name "location" in their variable names instead of "block".



* **New feature: TopN customization now possible.  The messages and placeholders that you can use are located in the core multi-language files.**
See the bottom of the files for instructions on usage.
TopN data is set to delay load so it does not lengthen the startup process.  As such, it now reports that the data is being loaded so it is now clear why there are no entries in the list initially.



* **Prison support listeners: added support for listening to and providing dumps for PlayerDropItemEvent, PlayerPickupItemEvent, and BlockPlaceEvent.**


* **Promote & Demote: Improved upon reporting issues with the command.**
There were few situations where the command would exit without reporting why, which was leading to difficulties with using the command effectively. 


* **Mine bombs: add support for BlockPlacementEvent so if someone is using a Block they can use it as the mine bomb's item.**


* **Prison's NBT: Add support for using NBTs with bukkit's Block.**



* **PlaceholderAPI: Upgrade from v2.11.2 to v2.11.5**


* **XSeries: Upgrade from v9.8.0 to v9.9.0**



**3.3.0-alpha.16c 2024-03-11** 



* **Mine Bombs: wrapped up the changes to enable the placement of a mine bomb when using the BlockPlaceEvent which is used when using a block for the bomb's item.**


* **Prison ItemStack: remove enchantments from the core ItemStack since prison cannot properly represent it in versions lower than 1.13.x**, plus it was wrong for all spigot versions greater than 1.12.x.
Added the proper enchantment functions to the SpigotItemStack object.




* **Sellall: New command:  '/sellall items inspect'**
This new command will inspect what the player is holding, and dump the details so the admin can see exactly how an item/block is created, including lore and enchantments.
Eventually this information can be used to enhance the ability to sell and buy non-standard items by allowing the admins to filter on lore, enchantments, and/or NBTs.



* **SpigotPlayer: Fixed a potential issue if trying to use getRankPlayer() if the ranks module is not enabled.**
Added a check to ensure it's active.
We have not seen any reports of issues related to this.





* **Prison API: Added a few new functions to work with ItemStacks.**




* **Localization: If admin adds extra parameters, or other parsing failures, happens on a message, the error will now be trapped and logged to the console without formatting.**



* **Economy: For economies that prison supports that has a method to check if the player has an account, prison now tries to check if there is an account for the player before trying to use the economy.**
This could potentially prevent issues or run time failures.


* **Player Manager: Secondary Placeholders:  Setup the secondary placeholder support on the PlayerManager, but it has not been enabled yet** since secondary placeholders on placeholders do not make a lot of sense because each placeholder is only one value and they cannot contain alternative text.  At least not yet.


* **Localizable: Secondary placeholders:  Rewrote the whole support of secondary placeholders related to players.***
Expanded the support by making them generic so other data sources can also have their own custom set of placeholders too.  Such as mines.
This now supports a new interface that will provide the generic support.
Player's commands have been modified to pass a RankPlayer object, which supports the new interface.  Non-player commands have not been converted since players will never see those messages (such as admin commands).



* **Placeholder bug: The placeholder 'prison_rankup_cost_percent' uses the calculated value of a percentage, but when used with the placeholder attribute, it was found to use the price instead.**  As such, the actual value returned for the placeholder was incorrect.



* **Mines messages: Secondary placeholders.  Added support for mines' messages to be able to support secondary placeholders within the language files. NOTE: Not usable at this time.**
But... this is basically useless.  Within the mines language files, the vast majority of all messages are related to admin messages and are not viewable by the players.
Therefore the admin-only messages will not support the secondary placeholders since the players will never see them.
At this time, there are no messages that supports the use of these secondary placeholders, although the feature has been enabled for mines.
If a need is required, then please reach out and request such features should be enabled.  At this time, effort and work will not be performed blindly upon items that will never be used, so if you see a need for this, I'd be happy to add them since you would have a need.

