### PR TITLE
Bleeding branch v3.3.0 alpha.18a

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ If hassle-free updates and zero payments is not enough for you to consider switc
 ## Get Prison
 
 
-| SpigotMC.org | Polymart.org | Bukkit.org | Experimental |
-| ------------ | ------------ | ---------- | ------------ |
-|    Stable    |    Stable    |   Stable   |    *Nightly*  |
-| [![Stable Download](https://img.shields.io/badge/download-stable-44cc11.svg)](https://www.spigotmc.org/resources/prison.1223/) | [![Stable Download](https://img.shields.io/badge/download-stable-44cc11.svg)](https://polymart.org/resource/prison-1-8-x-1-16-5.678/updates) | [![Stable Download](https://img.shields.io/badge/download-stable-44cc11.svg)](https://dev.bukkit.org/projects/mc-prison-v3) | [![Experimental Download](https://img.shields.io/badge/download-experimental-red.svg)](https://ci.appveyor.com/project/faizaand/prison/build/artifacts) | 
+| SpigotMC.org | Polymart.org | Bukkit.org | CurseForge.com | Experimental |
+| ------------ | ------------ | ---------- | -------------- | ------------ |
+|    Stable    |    Stable    |   Stable   |     Stable     |    *Nightly*  |
+| [![Stable Download](https://img.shields.io/badge/download-stable-44cc11.svg)](https://www.spigotmc.org/resources/prison.1223/) | [![Stable Download](https://img.shields.io/badge/download-stable-44cc11.svg)](https://polymart.org/resource/prison-1-8-x-1-16-5.678/updates) | [![Stable Download](https://img.shields.io/badge/download-stable-44cc11.svg)](https://dev.bukkit.org/projects/mc-prison-v3) | [![Stable Download](https://img.shields.io/badge/download-stable-44cc11.svg)](https://www.curseforge.com/minecraft/bukkit-plugins/mc-prison-v3) | [![Experimental Download](https://img.shields.io/badge/download-experimental-red.svg)](https://ci.appveyor.com/project/faizaand/prison/build/artifacts) | 
 
 
 

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,9 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.18 2024-05-21
 
 
+* **Docs... added curseForge.com to the list of locations where prison can be downloaded from.**
+
+
 
 * **Fix to the docs... for some reason, eclispse, or one of it's plugins failed and corrupted the markdown.**
 I did not realize it was corrupted since it was still showing the correct content, but when restarting the IDE and loading the files, they were missing the first characters.

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,9 +14,12 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.18 2024-05-20
+# 3.3.0-alpha.18 2024-05-21
 
 
+
+* **Fix to the docs... for some reason, eclispse, or one of it's plugins failed and corrupted the markdown.**
+I did not realize it was corrupted since it was still showing the correct content, but when restarting the IDE and loading the files, they were missing the first characters.
 
 
 **Prison v3.3.0-alpha.18 2024-05-20**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -14,7 +14,11 @@
 These change logs represent the work that has been going on within prison. 
 
 
-# 3.3.0-alpha.18 2024-05-21
+# 3.3.0-alpha.18a 2024-05-21
+
+
+**v3.3.0-alpha.18a 2024-05-21**
+Releasing this alpha.18a because the fix of the of the new player bug was crippling servers.
 
 
 * **Bug Fix: When a new player was joining prison, and there were placeholders being used in the rank commands for either the default ladder, or the first rank, the resolution of the placeholders was triggering a new player on-join processing within prison.**

--- a/docs/changelog_v3.3.x.md
+++ b/docs/changelog_v3.3.x.md
@@ -17,6 +17,11 @@ These change logs represent the work that has been going on within prison.
 # 3.3.0-alpha.18 2024-05-21
 
 
+* **Bug Fix: When a new player was joining prison, and there were placeholders being used in the rank commands for either the default ladder, or the first rank, the resolution of the placeholders was triggering a new player on-join processing within prison.**
+This happed because the new RankPlayer object was not being added to the PlayerManager before ranking the player... now the player's object will be there when the rank commands are processed.
+Honestly have no idea why this has not been an issue in the past....
+
+
 * **Docs... added curseForge.com to the list of locations where prison can be downloaded from.**
 
 

--- a/docs/prison_changelog_v3.3.0-alpha.18.md
+++ b/docs/prison_changelog_v3.3.0-alpha.18.md
@@ -51,110 +51,71 @@ This version has been tested and confirmed to be working with Spigot v1.20.6 and
 
 
 
- **Player Ranks GUI:  Fixed an issue with the code not using the correct defaults for NoRankAccess when no value is provided in the configs.**
+* **Player Ranks GUI:  Fixed an issue with the code not using the correct defaults for NoRankAccess when no value is provided in the configs.**
+
+
+* **Obsolete blocks: Marked an enum as @Deprecated to suppress a compile warning.**  This has not real impact on anything.
+
+
+* **Gradle updates:**
+Upgraded XSeries from v9.10.0 to v10.0.0
+Upgraded nbtApi from v2.12.2 to v2.12.4
+Upgraded luckperms-v5 from v5.0 to v5.4
+
+
+* **Economy: Added a feature to check if a player has an economy account.**
+Currently this is not being used outside of the economy integrations, but it can be used to help suppress initial startup messages where players do not have an account, which will help prevent flooding a lot of messages to the console for some servers.
+
+
+* **Player Cache: There was a report of a concurrent modification exception.**
+This is very rare and generally should not happen.
+The keySet is part of the original TreeMap collection, so the fix here is to take all keys and put them in a new collection so they are then disconnected from the original TreeSet.
+This will prevent a concurrent modification exception if there is an action to add or remove users from the user cache, since the user cache remains active and cannot be locked with a synchronization for any amount of time, other than then smallest possible.
+The standard solution with dealing with this TreeSet collection would be to synchronize the whole activity of saving the dirty elements of the player cache.  Unfortunately, that will cause blocking transactions when player events try to access the player cache.  Therefore it's a balance game of trying to protect the player cache with the minimal amount of synchronizations, but allow the least amount of I/O blocking for all other processes that are trying to use it.
+Hopefully this is sufficient to allow it all to work without conflict, and to be able to provide enough protection.
+
+
+* **Gradle: Removed a lot of the older commented out settings.**
+See prior commits to better understand how things were setup before, or for references.
+
+
+* **Gradle: A few more adjustments to add a few more items to the libs.versions.toml.**
 
 
 
- **Obsolete blocks: Marked an enum as @Deprecated to suppress a compile warning.**  This has not real impact on anything.
+* **Placeholders:  The placeholder api call from PlaceholderAPI is passing a null OfflinePlayer object.**
+Not sure why this has never been an issue before, but added support for null OfflnePlayers.
 
 
 
- **Gradle updates:**
-
-pgraded XSeries from v9.10.0 to v10.0.0
-
-pgraded nbtApi from v2.12.2 to v2.12.4
-
-pgraded luckperms-v5 from v5.0 to v5.4
+* **Spiget: Updated the way prison handles spiget by now submitting a task with a 5 second delay.**
+TThe messages are more helpful now.
+TThis also moves it out of the SpigotPrison class.
 
 
-
- **Economy: Added a feature to check if a player has an economy account.**
-
-urrently this is not being used outside of the economy integrations, but it can be used to help suppress initial startup messages where players do not have an account, which will help prevent flooding a lot of messages to the console for some servers.
-
-
-
- **Player Cache: There was a report of a concurrent modification exception.**
-
-his is very rare and generally should not happen.
-
-he keySet is part of the original TreeMap collection, so the fix here is to take all keys and put them in a new collection so they are then disconnected from the original TreeSet.
-
-his will prevent a concurrent modification exception if there is an action to add or remove users from the user cache, since the user cache remains active and cannot be locked with a synchronization for any amount of time, other than then smallest possible.
-
-he standard solution with dealing with this TreeSet collection would be to synchronize the whole activity of saving the dirty elements of the player cache.  Unfortunately, that will cause blocking transactions when player events try to access the player cache.  Therefore it's a balance game of trying to protect the player cache with the minimal amount of synchronizations, but allow the least amount of I/O blocking for all other processes that are trying to use it.
-
-opefully this is sufficient to allow it all to work without conflict, and to be able to provide enough protection.
-
-
-
- **Gradle: Removed a lot of the older commented out settings.**
-
-ee prior commits to better understand how things were setup before, or for references.
-
-
-
- **Gradle: A few more adjustments to add a few more items to the libs.versions.toml.**
-
-
-
-
- **Placeholders:  The placeholder api call from PlaceholderAPI is passing a null OfflinePlayer object.**
-
-ot sure why this has never been an issue before, but added support for null OfflnePlayers.
-
-
-
-
- **Spiget: Updated the way prison handles spiget by now submitting a task with a 5 second delay.**
-
-he messages are more helpful now.
-
-his also moves it out of the SpigotPrison class.
-
-
-
- **Upgraded John Rengelman's shadow, a gradle plugin, from v6.1.0 to v8.1.1**
-
-
-
-
-
- **Upgrade gradle from v7.6.4 to v8.7**
-
- Upgraded from: v7.6.4 -> v8.0 -> v8.0.2 -> v8.1 -> v8.1.1
-
- 		-> v8.2 -> v8.3 -> v8.4 -> v8.5 -> v8.6 -> v8.7
-
- v8.3 required a configuration change due to `org.gradle.api.plugins.BasePluginConvention` type has been deprecated and will be removed in gradle v9.x.  This is impacting the use of the `build.gradle`'s `archivesBaseNamme`.  This is being replaced by the new `base{}` configuration block.
-
- v8.3 also required other config changes.
+* **Upgraded John Rengelman's shadow, a gradle plugin, from v6.1.0 to v8.1.1**
 
  
 
+* **Upgrade gradle from v7.6.4 to v8.7**
+  Upgraded from: v7.6.4 -> v8.0 -> v8.0.2 -> v8.1 -> v8.1.1
+  		-> v8.2 -> v8.3 -> v8.4 -> v8.5 -> v8.6 -> v8.7
+  v8.3 required a configuration change due to `org.gradle.api.plugins.BasePluginConvention` type has been deprecated and will be removed in gradle v9.x.  This is impacting the use of the `build.gradle`'s `archivesBaseNamme`.  This is being replaced by the new `base{}` configuration block.
+  v8.3 also required other config changes.
+  
 
 
- **Upgrade spiget from v1.4.2 to v1.4.6**
+* **Upgrade spiget from v1.4.2 to v1.4.6**
+  Was using a jar with v1.4.2 due to their repo going down frequently.
+  Switched back to pulling through maven and got rid of jar.
+  
 
- Was using a jar with v1.4.2 due to their repo going down frequently.
-
- Switched back to pulling through maven and got rid of jar.
-
- 
-
-
- **Upgrade gradle from v7.3.3 to v7.6.4**
-
- Upgraded from: v7.3.3 -> v7.4 -> v7.4.1 -> v7.4.2 
-
- 		-> v7.5 -> v7.5.1 -> v7.6 -> v7.6.1 -> v7.6.2 -> v7.6.3 -> v7.6.4
-
- Preparing for Gradle v8.x
-
- Around v7.5.1 required a change to auto provisioning
-
- 
+* **Upgrade gradle from v7.3.3 to v7.6.4**
+  Upgraded from: v7.3.3 -> v7.4 -> v7.4.1 -> v7.4.2 
+  		-> v7.5 -> v7.5.1 -> v7.6 -> v7.6.1 -> v7.6.2 -> v7.6.3 -> v7.6.4
+  Preparing for Gradle v8.x
+  Around v7.5.1 required a change to auto provisioning
+  
 
 
 *v3.3.0-alpha.17a 2024-04-29**
@@ -171,9 +132,9 @@ his also moves it out of the SpigotPrison class.
 
  **Initial setup of the GUI tools messages that are at the bottom of a page.**
 
-etup the handling of the messages and added the messages to all of the language files.
+Setup the handling of the messages and added the messages to all of the language files.
 
-upport for prior, current, and next page. Also c
+Support for prior, current, and next page. Also c
 
  **Update the plugin.yml and removed the permissions configs since they were generating errors (lack of a schema) and the perms and handled through the prison command handler.**
 
@@ -182,7 +143,7 @@ upport for prior, current, and next page. Also c
 
  **CustomItems: Fixed an issue when CustomItems is a plugin on the server, but the plugin fails to load.**
 
-herefore the problem was fixed to allow a failed CustomItems loading to bypass being setup and loaded for prison.
+Therefore the problem was fixed to allow a failed CustomItems loading to bypass being setup and loaded for prison.
 
 CustomItems.isEnabled()` must exist and return a value of true before the integration is enabled.
 
@@ -190,11 +151,11 @@ CustomItems.isEnabled()` must exist and return a value of true before the integr
 
  **XSeries XMaterials: Update to XSeries v9.10.0 from v9.9.0.**
 
-ad issues with case sensitivity when using `valueOf()`, which was changed to `matchXMaterial().orElse(null)` which resolves a few issues.
+Had issues with case sensitivity when using `valueOf()`, which was changed to `matchXMaterial().orElse(null)` which resolves a few issues.
 
 Materials v9.10.0 sets up support for spigot 1.20.5. There may be more changes as spigot stabilizes.
 
-he issue with using `valueOf("green_wool")` would not find any matches since the enum case must match the string value exactly.  So `valueOf("GREEN_WOOL")` would have worked.  This was fixed to help eliminate possible issues with configuring the server.
+The issue with using `valueOf("green_wool")` would not find any matches since the enum case must match the string value exactly.  So `valueOf("GREEN_WOOL")` would have worked.  This was fixed to help eliminate possible issues with configuring the server.
 
 
 
@@ -205,7 +166,7 @@ he issue with using `valueOf("green_wool")` would not find any matches since the
 
  **Auto features: Inventory full chat notification: bug fix.  This fixes using the wrong player object.**
 
-t now use prison's player object so the color codes are properly translated.
+It now use prison's player object so the color codes are properly translated.
 
 
 
@@ -223,7 +184,7 @@ t now use prison's player object so the color codes are properly translated.
 
  **GUI: Player ranks: Fixed a bug where clicking on a rank in the player's gui was trying to run an empty command, which was generating an invalid command error.**
 
-gnores the command running if the command is either null or blank.
+Ignores the command running if the command is either null or blank.
 
 
 
@@ -234,13 +195,13 @@ gnores the command running if the command is either null or blank.
 
  **Economies: fixed the display of too many economy related messages, including eliminating logging of messages for offline players.**
 
-he vault economy check for offline players, will now only show one informational message if a player is not setup in the economy.
+The vault economy check for offline players, will now only show one informational message if a player is not setup in the economy.
 
 
 
  **GUI Player ranks: The setting for Options.Ranks.MaterialType.NoRankAccess was not hooked up properly so it was not really working.**
 
-he config creation was wrong.  Also fixed the code that was generating the gui.
+The config creation was wrong.  Also fixed the code that was generating the gui.
 
 
 
@@ -250,15 +211,15 @@ he config creation was wrong.  Also fixed the code that was generating the gui.
 
  **Update privatebin-java-api to a newer release that now does a better job with a failure to use the correct protocol.**
 
-t identifies what TLS version is being used, and if TLSv1.3 is missing, then it will indicate that the java version needs to be updated.
+It identifies what TLS version is being used, and if TLSv1.3 is missing, then it will indicate that the java version needs to be updated.
 
-s a fallback, if the privatebin cannot be used, it is now using the older paste.helpch.at service.  But if it does, the resulting documents are not purged and not encrypted.
+As a fallback, if the privatebin cannot be used, it is now using the older paste.helpch.at service.  But if it does, the resulting documents are not purged and not encrypted.
 
 
 
  **Economy: EdPrison's economy. Added support for use of EdPrison's economy and custom currencies.**
 
-his will allow prison to use EdPrison's economy does not also use another established economy that is accessible through vault, or multi-currency.
+This will allow prison to use EdPrison's economy does not also use another established economy that is accessible through vault, or multi-currency.
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.2.1-alpha.3
-version=3.3.0-alpha.18
+version=3.3.0-alpha.18a
 
 
 

--- a/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
+++ b/prison-core/src/main/java/tech/mcprison/prison/ranks/data/RankPlayer.java
@@ -322,6 +322,8 @@ public class RankPlayer
     			RankPlayerName rpn = new RankPlayerName( playerName, System.currentTimeMillis() );
     			getNames().add( rpn );
     			
+    			dirty = true;
+    			
     			added = true;
     		}
     	}
@@ -2021,6 +2023,15 @@ public class RankPlayer
 		}
 		
 		return results;
+	}
+
+	/**
+	 * Does nothing like the function name says.
+	 * 
+	 * This is just a placeholder so the compiler won't generate 
+	 * a variable not used warning.
+	 */
+	public void doNothing() {
 	}
 
 //	public long getRankScoreCooldown() {

--- a/prison-ranks/src/main/java/tech/mcprison/prison/ranks/data/RankPlayerFactory.java
+++ b/prison-ranks/src/main/java/tech/mcprison/prison/ranks/data/RankPlayerFactory.java
@@ -109,15 +109,19 @@ public class RankPlayerFactory
      * since it will skip processing for them.
      * </p>
      * 
-     * <p>Note, this will not save the player's new rank.  The save function must be
-     * managed and called outside of this.
+     * <p>Note, this will save the player's new rank.
      * </p>
      */
     public void firstJoin( RankPlayer rankPlayer) {
     	
     	RankLadder defaultLadder = PrisonRanks.getInstance().getDefaultLadder();
     	
-    	if ( !rankPlayer.getLadderRanks().containsKey( defaultLadder ) ) {
+    	if ( defaultLadder == null ) {
+    		
+    		Output.get().logError( "RankPlayerFactory.firstJoin: No default ladder!!" );
+    		
+    	}
+    	else if ( !rankPlayer.getLadderRanks().containsKey( defaultLadder ) ) {
     		
     		Optional<Rank> firstRank = defaultLadder.getLowestRank();
     		
@@ -130,6 +134,9 @@ public class RankPlayerFactory
     			rankupCommands.setPlayerRankFirstJoin( rankPlayer, defaultRank );
     			rankPlayer.setDirty( true );
     			
+    			
+    			// Saves the new player's rank:
+    			PrisonRanks.getInstance().getPlayerManager().savePlayer(rankPlayer);
     			
 //    			rankPlayer.addRank( defaultRank );
     			


### PR DESCRIPTION
Prison 3.3.0-alpha.18a 2024-05-21

But fix: There was a bug that surfaced that was being triggered by new player joins to the prison server.
The symptom was the spamming of new player join messages.
This was actually happening only if there were rank commands that would be ran for the initial rank assignment if it used rank related placeholder.  The resolution of the placeholders were triggering another new player cycle. 
This was a classic chicken or the egg situation.
It is unknown when this problem was first "setup", but it's only recently that it's been reported.  It may have been there in the code for a few years, so not sure how many times this was encountered without being reported.