### PR TITLE
Update github's actions for prison's internal build process when committing to github: gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v1
       with:
         java-version: 1.8
     - name: Gradlew permission

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 1.8
     - name: Gradlew permission
@@ -19,7 +19,7 @@ jobs:
       run: ./gradlew build
 
     - name: Upload Jar
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: Prison
           path: prison-spigot/build/libs/


### PR DESCRIPTION
File changed: gradle.yml

Reason: github has disabled the use of v1 and v2 of most actions and therefore prison's build process fails when source is checked in.  This is a critical update to allow the builds to work properly.

Github updated their actions, whereas the checkout and upload-artifact are currently at v4 and v1 and v2 has been disabled and must change. v3 will be disabled in about 2 months, so only makes sense to update to v4. actions/setup-java has also been updated to v2, but not sure if v1 is yet depricated; updating now to bypass near future issues if it will too be disabled.