### PR TITLE
SellAll: PrePlayerSellAllEvent implementation

### DIFF
--- a/prison-sellall/src/main/java/tech/mcprison/prison/sellall/events/PrePlayerSellAllEvent.java
+++ b/prison-sellall/src/main/java/tech/mcprison/prison/sellall/events/PrePlayerSellAllEvent.java
@@ -1,0 +1,61 @@
+package tech.mcprison.prison.sellall.events;
+
+import tech.mcprison.prison.internal.ItemStack;
+import tech.mcprison.prison.internal.Player;
+import tech.mcprison.prison.internal.events.Cancelable;
+import tech.mcprison.prison.internal.inventory.PlayerInventory;
+
+/**
+ * Represents an event called when a player is about to sell all of their items
+ */
+public class PrePlayerSellAllEvent implements Cancelable {
+
+    private Player player;
+    private PlayerInventory inventory;
+
+    private boolean canceled = false;
+    private String cancelReason = null;
+
+    public PrePlayerSellAllEvent(Player player, PlayerInventory items) {
+        super();
+        this.player = player;
+        this.inventory = items;
+    }
+
+    /**
+     * Gets the player associated with this event
+     *
+     * @return the player associated with this event
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Gets the inventory associated with this event
+     *
+     * @return the inventory associated with this event
+     */
+    public PlayerInventory getInventory() {
+        return inventory;
+    }
+
+    /**
+     * Checks to see if this event has been canceled
+     *
+     * @return true if this event has been canceled, false otherwise
+     */
+    public boolean isCanceled() {
+        return canceled;
+    }
+
+    /**
+     * Sets the canceled status of this event
+     *
+     * @param canceled the new canceled status of this event
+     */
+    public void setCanceled(boolean canceled) {
+        this.canceled = canceled;
+    }
+
+}

--- a/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllUtil.java
+++ b/prison-spigot/src/main/java/tech/mcprison/prison/spigot/sellall/SellAllUtil.java
@@ -32,6 +32,7 @@ import tech.mcprison.prison.ranks.data.PlayerRank;
 import tech.mcprison.prison.ranks.data.Rank;
 import tech.mcprison.prison.ranks.data.RankLadder;
 import tech.mcprison.prison.ranks.data.RankPlayer;
+import tech.mcprison.prison.sellall.events.PrePlayerSellAllEvent;
 import tech.mcprison.prison.sellall.messages.SpigotVariousGuiMessages;
 import tech.mcprison.prison.spigot.SpigotPrison;
 import tech.mcprison.prison.spigot.block.SpigotItemStack;
@@ -772,8 +773,16 @@ public class SellAllUtil
     	
     	SpigotPlayerInventory spInventory = sPlayer.getSpigotPlayerInventory();
 
-    	return sellInventoryItems( spInventory, multiplier );
-	}
+        // Pass onto event bus for any plugins to edit/cancel the sale.
+        PrePlayerSellAllEvent preSaleEvent = new PrePlayerSellAllEvent( sPlayer, spInventory );
+        Prison.get().getEventBus().post(preSaleEvent);
+
+        if ( preSaleEvent.isCanceled() ) {
+            return new ArrayList<>();
+        }
+
+        return sellInventoryItems( spInventory, multiplier );
+    }
 
     /**
      * <p>This function sells the Item Stacks and returns a transaction log of items sold.


### PR DESCRIPTION
This PR adds the ability for other plugins to hook into the sellall functionality in the Prison plugin.

Added events
- PrePlayerSellALlEvent

Added a call in the SellAll util to call this event prior to finalising the sale method.